### PR TITLE
[LEVWEB-50] Add date of registration

### DIFF
--- a/models/stubs.js
+++ b/models/stubs.js
@@ -21,7 +21,8 @@ module.exports = [{
     'jointly': 'Yes',
     'district': 'Oxfordshire',
     'sub-district': 'Cherwell',
-    'admin-area': 'Oxfordshire'
+    'admin-area': 'Oxfordshire',
+    'date': '12/12/1983'
   }
 }, {
   'system-number': '98765',
@@ -44,7 +45,8 @@ module.exports = [{
     'jointly': 'No',
     'district': 'Norfolk',
     'sub-district': 'Norwich',
-    'admin-area': 'Norfolk'
+    'admin-area': 'Norfolk',
+    'date': '25/09/1976'
   }
 }, {
   'system-number': '00001',
@@ -67,8 +69,9 @@ module.exports = [{
     'jointly': 'Yes',
     'district': 'Kent',
     'sub-district': 'Medway',
-    'admin-area': 'Kent'
-  },
+    'admin-area': 'Kent',
+    'date': '15/02/1980'
+  }
 }, {
   'system-number': '99999',
   forenames: 'Sarah',
@@ -90,6 +93,7 @@ module.exports = [{
     'jointly': 'Yes',
     'district': 'Sussex',
     'sub-district': 'Brighton & Hove',
-    'admin-area': 'Sussex'
+    'admin-area': 'Sussex',
+    'date': '04/02/1979'
   }
 }];

--- a/views/pages/details.html
+++ b/views/pages/details.html
@@ -85,6 +85,10 @@
         <th><span class="visuallyhidden" aria-hidden="true">Registration </span>Administrative area</th>
         <td>{{record.registered.admin-area}}</td>
       </tr>
+      <tr>
+        <th>Date of registration</th>
+        <td>{{record.registered.date}}</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
"Add 'Date of registration' as a new separate field on the birth record
view at the bottom of the list of fields (below the Registration
district block, but as a separate field rather than part of that block)"