### PR TITLE
[LEVWEB-71] Remove hover decoration on crown image

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -169,3 +169,8 @@ div.search-buttons {
     margin: 0;
   }
 }
+
+/* Override govuk-template.css */
+#global-header #logo:hover, #global-header #logo:focus {
+  border-bottom: none;
+  padding-bottom: 1px; }


### PR DESCRIPTION
This removes the mock-hyperlink hover behaviour from the crown image's
parent div. This is desirable as we no longer have a link on this image.

"Design Review: Crown in Header is a link to nowhere

The Crown image in the header has a hover state so it looks like a link
but goes nowhere. Suggest removing this so it is just an image."