### PR TITLE
fix for messy acceptance tests teardown

### DIFF
--- a/api/mock/index.js
+++ b/api/mock/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-process.title = 'levapimock';
+process.title = 'levapi';
 
 var app = require('connect')();
 var http = require('http');

--- a/api/mock/package.json
+++ b/api/mock/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "NODE_ENV=development node .",
-    "stop": "pkill levapimock"
+    "stop": "pkill levapi"
   },
   "keywords": [
     "swagger"


### PR DESCRIPTION
It appears that process.name has slightly obtuse limits.

https://nodejs.org/dist/latest-v4.x/docs/api/process.html#process_process_title

This change ensures the teardown works on *nix and OSX.