### PR TITLE
 [LEVWEB-152] Show generic message for all flags

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -59,9 +59,9 @@ module.exports = {
           blockedRegistration: record.status.blockedRegistration,
           cancelled: record.status.cancelled,
           cautionMark: record.status.cautionMark,
-          courtOrder: record.status.courtOrder,
+          courtOrder: (record.status.courtOrder == 'None') ? '' : record.status.courtOrder,
           fictitiousBirth: record.status.fictitiousBirth,
-          reRegistered: record.status.reRegistered
+          reRegistered: (record.status.reRegistered == 'None') ? '' : record.status.reRegistered
         },
         previousRegistration: record.status.blockedRegistration ? {
           date: null,

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -215,3 +215,28 @@ div.search-buttons {
 #global-header #logo:hover, #global-header #logo:focus {
   border-bottom: none;
   padding-bottom: 1px; }
+
+/* Flags */
+.flag {
+  display: block;
+  background-color: #eee;
+  border-left: 10px solid #ccc;
+  padding: 15px;
+  margin-bottom: 20px;
+}
+
+.alert {
+  background-color: #fcc;
+  border-left: 10px solid #c00;
+  color: #c00;
+}
+
+#records .flag {
+  display: block;
+  background-color: transparent;
+  border-left: none;
+  padding: 0;
+  margin-bottom: 0;
+  font-weight: bold;
+}
+

--- a/views/pages/details.html
+++ b/views/pages/details.html
@@ -23,6 +23,24 @@
 {{/maincontent}}
 
 {{$content}}
+  {{#record.status.blockedRegistration}}
+  <div class="flag alert">Record flagged, consider referral.</div>
+  {{/record.status.blockedRegistration}}
+  {{#record.status.cancelled}}
+  <div class="flag alert">Record flagged, consider referral.</div>
+  {{/record.status.cancelled}}
+  {{#record.status.cautionMark}}
+  <div class="flag alert">Record flagged, consider referral.</div>
+  {{/record.status.cautionMark}}
+  {{#record.status.courtOrder}}
+  <div class="flag alert">Record flagged, consider referral.</div>
+  {{/record.status.courtOrder}}
+  {{#record.status.fictitiousBirth}}
+  <div class="flag alert">Record flagged, consider referral.</div>
+  {{/record.status.fictitiousBirth}}
+  {{#record.status.reRegistered}}
+  <div class="flag alert">Record flagged, consider referral.</div>
+  {{/record.status.reRegistered}}
   <table>
     <tbody>
       <tr>

--- a/views/pages/results.html
+++ b/views/pages/results.html
@@ -56,6 +56,24 @@
               </tr>
             </tbody>
           </table>
+          {{#status.blockedRegistration}}
+          <div class="flag alert">Record flagged, consider referral.</div>
+          {{/status.blockedRegistration}}
+          {{#status.cancelled}}
+          <div class="flag alert">Record flagged, consider referral.</div>
+          {{/status.cancelled}}
+          {{#status.cautionMark}}
+          <div class="flag alert">Record flagged, consider referral.</div>
+          {{/status.cautionMark}}
+          {{#status.courtOrder}}
+          <div class="flag alert">Record flagged, consider referral.</div>
+          {{/status.courtOrder}}
+          {{#status.fictitiousBirth}}
+          <div class="flag alert">Record flagged, consider referral.</div>
+          {{/status.fictitiousBirth}}
+          {{#status.reRegistered}}
+          <div class="flag alert">Record flagged, consider referral.</div>
+          {{/status.reRegistered}}
         </a>
       </article>
     </li>


### PR DESCRIPTION
Adds a generic message to display on the results and details pages on
all flags returned by the API.

Includes CSS for displaying them. (Is there some GovUK pattern we can take off the peg instead?)