### PR TITLE
[LEVWEB-162] Log-out support

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,12 @@ app.use(function setBaseUrl(req, res, next) {
   next();
 });
 
+app.use(function setAbsoluteBaseUrl(req, res, next) {
+  res.locals.absoluteBaseUrl = req.protocol + '://' + req.get('host') + req.baseUrl;
+  res.locals.absoluteBaseUrlEscaped = encodeURIComponent(res.locals.absoluteBaseUrl);
+  next();
+});
+
 app.set('view engine', 'html');
 app.set('views', path.resolve(__dirname, './views'));
 require('hmpo-govuk-template').setup(app);

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -240,3 +240,11 @@ div.search-buttons {
   font-weight: bold;
 }
 
+#nav {
+  display: block;
+  text-align: right;
+
+  .button {
+    margin: 0;
+  }
+}

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   search: require('./search'),
   results: require('./results'),
-  details: require('./details')
+  details: require('./details'),
+  loggedOut: require('./logged-out')
 };

--- a/controllers/logged-out.js
+++ b/controllers/logged-out.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function renderLoggedOut(req, res) {
+  // FIXME: Delete once no longer needed!
+  res.clearCookie('kc-access');
+
+  // Render page
+  res.render('pages/logged-out');
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,5 +6,6 @@ module.exports = function defineRoutes(app) {
   app
     .get('/', controllers.search.show)
     .get('/results', controllers.results.query)
-    .get('/details/:sysnum?', controllers.details);
+    .get('/details/:sysnum?', controllers.details)
+    .get('/logged-out', controllers.loggedOut);
 };

--- a/views/layout.html
+++ b/views/layout.html
@@ -105,6 +105,7 @@
 
     {{$main}}
       <main id="content" class="main" role="main">
+        <div id="nav"><a id="logout" class="button" href="https://keycloak.digital.homeoffice.gov.uk/auth/realms/lev-dev/protocol/openid-connect/logout?redirect_uri={{absoluteBaseUrlEscaped}}/logged-out">Logout</a></div>
         <div class="grid-row">
           {{$maincontent}}{{/maincontent}}
         </div>

--- a/views/pages/logged-out.html
+++ b/views/pages/logged-out.html
@@ -1,0 +1,29 @@
+{{<layout}}
+
+{{$title}}Birth record check{{/title}}
+
+{{$journeyHeader}}
+  Birth record check
+{{/journeyHeader}}
+
+{{$propositionHeader}}
+  {{> partials-navigation}}
+{{/propositionHeader}}
+
+{{$header}}
+  {{<partials-page-header}}
+    {{$page-header}}
+      Logged out
+    {{/page-header}}
+  {{/partials-page-header}}
+{{/header}}
+
+{{$maincontent}}
+  {{> partials-maincontent-left}}
+{{/maincontent}}
+
+{{$content}}
+  <p>You have been logged out.</p>
+{{/content}}
+
+{{/layout}}


### PR DESCRIPTION
Adds a "Logout" button to all pages. The button links through to the
KeyCloak logout URL, which then redirects back to a new endpoint,
/logged-out.

Unfortunately this does not, on its own, revoke access to the website.
This is probably a bug in go-keycloak-proxy but we are not certain at
this time. In order to secure the logout the endpoint clears the
kc-access cookie. Once the bug is fixed in go-keycloak-proxy this extra
functionality should be removed.

Note: This is not fully tested, as I could not think of a way to do so
without first deploying.