### PR TITLE
[LEVWEB-236] HTTPS support when connecting to API

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -83,7 +83,9 @@ var processRecord = function processRecord(record) {
   };
 };
 
-var endpoint = 'http://' + config.api.host + ':' + config.api.port + '/api/v0/events/birth';
+var endpoint = config.api.protocol + '://' +
+               config.api.host + ':' + config.api.port +
+               '/api/v0/events/birth';
 
 var requestData = function requestData(url, callback) {
   return new Promise(function requestDataPromise(resolve, reject) {

--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@
 /*eslint camelcase: 0*/
 /*eslint no-multi-spaces: 0*/
 var api = {
+  protocol: process.env.API_PROTOCOL || 'http',
   host: process.env.API_PORT_8080_TCP_ADDR || process.env.API_HOST || 'localhost',
   port: process.env.API_PORT_8080_TCP_POST || process.env.API_PORT || 8080
 };
@@ -16,6 +17,7 @@ module.exports = {
   listen_host: process.env.LISTEN_HOST || '0.0.0.0',
   api: {
     real: api,
+    protocol: process.env.NODE_ENV === 'acceptance' ? 'http' : api.host,
     host: process.env.NODE_ENV === 'acceptance' ? 'localhost' : api.host,
     port: process.env.NODE_ENV === 'acceptance' ? 8081 : api.port
   },

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -136,6 +136,7 @@ describe('api', function() {
       request: request,
       '../config': _.extend(config, {
         api: {
+          protocol: 'http',
           host: 'testhost.com',
           port: 1111
         },
@@ -167,7 +168,7 @@ describe('api', function() {
         });
       });
 
-      it('Uses oAuth2 authorization it oAuth2 environment variables are set', function() {
+      it('Uses oAuth2 authorization if oAuth2 environment variables are set', function() {
         var successfulAuthResponse = {
           "access_token": "access_token",
           "expires_in": 300,
@@ -183,6 +184,7 @@ describe('api', function() {
           request: request,
           '../config': _.extend(config, {
             api: {
+              protocol: 'http',
               host: 'testhost.com',
               port: 1111
             },


### PR DESCRIPTION
Adds support for connecting to the API over HTTPS. (Still defaults to
HTTP.)

The protocol can now be configured via an environment variable.