### PR TITLE
[LEVWEB-258] Use proper logout endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,13 +25,6 @@ app.use(function setBaseUrl(req, res, next) {
   next();
 });
 
-app.use(function setAbsoluteBaseUrl(req, res, next) {
-  res.locals.absoluteBaseUrl = 'https://' + req.get('host') + req.baseUrl;
-  res.locals.absoluteBaseUrlEscaped = encodeURIComponent(res.locals.absoluteBaseUrl);
-  res.locals.keycloakRealm = config.keycloakRealm;
-  next();
-});
-
 app.set('view engine', 'html');
 app.set('views', path.resolve(__dirname, './views'));
 require('hmpo-govuk-template').setup(app);

--- a/config.js
+++ b/config.js
@@ -30,6 +30,5 @@ module.exports = {
     clientSecret: process.env.CLIENT_SECRET,
     username: process.env.KEYCLOAK_U,
     password: process.env.KEYCLOAK_P
-  },
-  keycloakRealm: process.env.KEYCLOAK_WEB_REALM
+  }
 };

--- a/controllers/logged-out.js
+++ b/controllers/logged-out.js
@@ -1,12 +1,5 @@
 'use strict';
 
 module.exports = function renderLoggedOut(req, res) {
-  // FIXME: Delete once no longer needed!
-  res.clearCookie('kc-access', {
-    domain: '.' + req.get('host'),
-    path: '/'
-  });
-
-  // Render page
   res.render('pages/logged-out');
 };

--- a/views/layout.html
+++ b/views/layout.html
@@ -105,7 +105,7 @@
 
     {{$main}}
       <main id="content" class="main" role="main">
-        <div id="nav"><a id="logout" class="button" href="https://sso.digital.homeoffice.gov.uk/auth/realms/{{keycloakRealm}}/protocol/openid-connect/logout?redirect_uri={{absoluteBaseUrlEscaped}}/logged-out">Logout</a></div>
+        <div id="nav"><a id="logout" class="button" href="/oauth/logout?redirect=%2Flogged-out">Logout</a></div>
         <div class="grid-row">
           {{$maincontent}}{{/maincontent}}
         </div>


### PR DESCRIPTION
Makes use of the dedicated logout endpoint provided by newer versions of
keycloak-proxy. Eliminates the need for us to delete its cookie
ourselves.