### PR TITLE
[LEVWEB-292] Only search on first forename

### DIFF
--- a/test/acceptance/expectedRecords.js
+++ b/test/acceptance/expectedRecords.js
@@ -16,7 +16,7 @@ if (testConfig.env === 'local') {
     'registrationDistrict': 'Test District',
     'child': {
       'originalName': {
-        'givenName': 'Tester One',
+        'givenName': 'Tester',
         'surname': 'Multiple',
         'fullName': 'Tester One Multiple'
       },

--- a/test/acceptance/spec/10-search.js
+++ b/test/acceptance/spec/10-search.js
@@ -44,12 +44,12 @@ describe('Search', () => {
     });
 
     describe('that returns more than 1 record', () => {
-      before(() => {
-        const child = expectedRecords.child;
-        const name = child.originalName;
+      const child = expectedRecords.child;
+      const name = child.originalName;
 
+      before(() => {
         mockProxy.willReturnForLocalTests(3);
-        browser.search('', name.surname, name.givenName, '');
+        browser.search('', name.surname, name.givenName, child.dateOfBirth);
       });
 
       it('returns a results page', () => {
@@ -57,7 +57,7 @@ describe('Search', () => {
       });
 
       it('displays an appropriate message', () => {
-        browser.getText('h1').should.equal('3 records found for Tester Solo');
+        browser.getText('h1').should.equal('3 records found for ' + name.givenName + ' ' + name.surname + ' ' + child.dateOfBirth);
       });
 
       it('displays a subset of each record in a list', () => {


### PR DESCRIPTION
Makes the searches in the e2e tests only search on one forename when
looking for multiple results.