### PR TITLE
[LEVWEB-307] Re-order info on result page

### DIFF
--- a/test/acceptance/spec/10-search.js
+++ b/test/acceptance/spec/10-search.js
@@ -71,14 +71,14 @@ describe('Search', () => {
         const motherNameRegex = motherName.givenName.split(' ')[0] + '.*' + motherName.surname;
 
         browserText[0].should.match(new RegExp('Place of birth ?' + birthplace));
-        browserText[1].should.match(new RegExp('Father ?' + fatherNameRegex));
-        browserText[2].should.match(new RegExp('Mother ?' + motherNameRegex));
+        browserText[1].should.match(new RegExp('Mother ?' + motherNameRegex));
+        browserText[2].should.match(new RegExp('Father ?' + fatherNameRegex));
         browserText[3].should.match(new RegExp('Place of birth ?' + birthplace));
-        browserText[4].should.match(new RegExp('Father ?' + fatherNameRegex));
-        browserText[5].should.match(new RegExp('Mother ?' + motherNameRegex));
+        browserText[4].should.match(new RegExp('Mother ?' + motherNameRegex));
+        browserText[5].should.match(new RegExp('Father ?' + fatherNameRegex));
         browserText[6].should.match(new RegExp('Place of birth ?' + birthplace));
-        browserText[7].should.match(new RegExp('Father ?' + fatherNameRegex));
-        browserText[8].should.match(new RegExp('Mother ?' + motherNameRegex));
+        browserText[7].should.match(new RegExp('Mother ?' + motherNameRegex));
+        browserText[8].should.match(new RegExp('Father ?' + fatherNameRegex));
       });
 
       it('contains a link back to the search screen', () => {

--- a/views/pages/results.html
+++ b/views/pages/results.html
@@ -42,32 +42,32 @@
                 <td>{{birth-place}}</td>
               </tr>
               <tr>
-                <th>Father</th>
-                <td>{{father.name}}</td>
-              </tr>
-              <tr>
                 <th>Mother</th>
                 <td>{{mother.name}}</td>
+              </tr>
+              <tr>
+                <th>Father</th>
+                <td>{{father.name}}</td>
               </tr>
             </tbody>
           </table>
           {{#status.blockedRegistration}}
-          <div class="flag alert">Record flagged, consider referral.</div>
+            <div class="flag alert">Record flagged, consider referral.</div>
           {{/status.blockedRegistration}}
           {{#status.cancelled}}
-          <div class="flag alert">Record flagged, consider referral.</div>
+            <div class="flag alert">Record flagged, consider referral.</div>
           {{/status.cancelled}}
           {{#status.cautionMark}}
-          <div class="flag alert">Record flagged, consider referral.</div>
+            <div class="flag alert">Record flagged, consider referral.</div>
           {{/status.cautionMark}}
           {{#status.courtOrder}}
-          <div class="flag alert">Record flagged, consider referral.</div>
+            <div class="flag alert">Record flagged, consider referral.</div>
           {{/status.courtOrder}}
           {{#status.fictitiousBirth}}
-          <div class="flag alert">Record flagged, consider referral.</div>
+            <div class="flag alert">Record flagged, consider referral.</div>
           {{/status.fictitiousBirth}}
           {{#status.reRegistered}}
-          <div class="flag alert">Record flagged, consider referral.</div>
+            <div class="flag alert">Record flagged, consider referral.</div>
           {{/status.reRegistered}}
         </a>
       </article>


### PR DESCRIPTION
Re-order the information on the results pages so that mother appears
above father the same way it does on the details page.