### PR TITLE
Do not require all TLS env vars to be set together

### DIFF
--- a/lib/lev-request.js
+++ b/lib/lev-request.js
@@ -9,9 +9,9 @@ const addTlsConfig = (requestArgs) => {
   if(config.lev_tls.key || config.lev_tls.cert || config.lev_tls.ca) {
     requestArgs = requestHelper.urlToObject(requestArgs);
 
-    requestArgs.key = fs.readFileSync(config.lev_tls.key);
-    requestArgs.cert = fs.readFileSync(config.lev_tls.cert);
-    requestArgs.ca = fs.readFileSync(config.lev_tls.ca);
+    requestArgs.key = config.lev_tls.key ? fs.readFileSync(config.lev_tls.key) : undefined;
+    requestArgs.cert = config.lev_tls.cert ? fs.readFileSync(config.lev_tls.cert) : undefined;
+    requestArgs.ca = config.lev_tls.ca ? fs.readFileSync(config.lev_tls.ca) : undefined;
   }
 
   return requestArgs;


### PR DESCRIPTION
Allows setting the key and cert but not the CA for example.