### PR TITLE
LEVWEB-334: Allow short date of birth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 #ide specific
 .idea/
 
-node_modules
-coverage
-public
+node_modules/
+build/
+coverage/
+public/
 *.log
 .DS_Store
 do
-api/mock/lev-api-docs
+api/mock/lev-api-docs/

--- a/controllers/search.js
+++ b/controllers/search.js
@@ -11,7 +11,9 @@ const _ = require('lodash');
 var validators = Parent.validators;
 validators = _.extend(validators, {
   'british-date': function britishDate(value) {
-    return value === '' || this.regex(value, /^\d{1,2}\/\d{1,2}\/\d{1,4}$/) && moment(value, 'DD/MM/YYYY').isValid();
+    return value === ''
+      || (this.regex(value, /^\d{1,2}\/\d{1,2}\/\d{1,4}$/) && moment(value, 'DD/MM/YYYY').isValid())
+      || (this.regex(value, /^\d{8}$/) && moment(value, 'DDMMYYYY').isValid());
   }.bind(validators)
 });
 

--- a/test/acceptance/spec/10-search.js
+++ b/test/acceptance/spec/10-search.js
@@ -86,6 +86,25 @@ describe('Search', () => {
       });
 
     });
+
+    describe('using the "fast entry" date format', () => {
+      const child = expectedRecords.child;
+      const name = child.name;
+      const dob = child.dateOfBirth.replace(/\//g, '');
+
+      before(() => {
+        mockProxy.willReturnForLocalTests(3);
+        browser.search('', name.surname, name.givenName, dob);
+      });
+
+      it('returns a results page', () => {
+        browser.shouldBeOnResultsPage();
+      });
+
+      it('displays an appropriate message', () => {
+        browser.getText('h1').should.equal('3 records found for ' + name.givenName + ' ' + name.surname + ' ' + dob);
+      });
+    });
   });
 
   describe('submitting an invalid query', () => {
@@ -124,6 +143,20 @@ describe('Search', () => {
     describe('with an invalid date', () => {
       before(() => {
         browser.search('', 'Churchill', 'Winston', 'invalid');
+      });
+
+      it('displays an error message', () => {
+        browser.getText('h2').should.contain('Fix the following error');
+      });
+
+      it('requests a British formatted date', () => {
+        browser.getText('a').should.contain('Please enter a date of birth in the correct format');
+      });
+    });
+
+    describe('with an invalid short date', () => {
+      before(() => {
+        browser.search('', 'Churchill', 'Winston', '112001');
       });
 
       it('displays an error message', () => {


### PR DESCRIPTION
Dates of birth can now be entered into the search box in a short format. The short format is exactly **eight** numbers of the form **DDMMYYYY**.