### PR TITLE
Show system number hint after validation error

### DIFF
--- a/test/acceptance/spec/10-search.js
+++ b/test/acceptance/spec/10-search.js
@@ -138,6 +138,10 @@ describe('Search', () => {
       it('requests a number', () => {
         browser.getText('a').should.contain('Please enter a number');
       });
+
+      it('shows the system number details hint', () => {
+        browser.isVisible('details > div').should.be.true;
+      });
     });
 
     describe('with an invalid date', () => {

--- a/views/pages/search.html
+++ b/views/pages/search.html
@@ -26,7 +26,7 @@
   {{<partials-form}}
     {{$form}}
       {{#input-text}}system-number{{/input-text}}
-      <details>
+      <details{{#errors.system-number}} open{{/errors.system-number}}>
         <summary><span class="summary">What is the system number?</span></summary>
         <div class="panel panel-border-narrow">
           <img


### PR DESCRIPTION
Show the system number hint (by expanding the details section), if a system number validation error occurs.

![image](https://cloud.githubusercontent.com/assets/7834222/17024746/fe3e8240-4f50-11e6-85f6-d27aa8450db6.png)
