### PR TITLE
Validate system numbers have exactly 9 digits

### DIFF
--- a/fields/index.js
+++ b/fields/index.js
@@ -2,7 +2,13 @@
 
 module.exports = {
   'system-number': {
-    validate: ['numeric']
+    validate: [
+      'numeric',
+      {
+        type: 'exactlength',
+        arguments: [9]
+      }
+    ]
   },
   'surname': {
     validate: ['required'],

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -26,7 +26,8 @@
   "validation": {
     "system-number": {
       "required": "Please enter a system number",
-      "numeric": "Please enter a number"
+      "numeric": "Please enter a number",
+      "exactlength": "The system number should be 9 digits"
     },
     "surname": {
       "required": "Please enter a surname"

--- a/test/acceptance/spec/10-search.js
+++ b/test/acceptance/spec/10-search.js
@@ -126,7 +126,7 @@ describe('Search', () => {
       });
     });
 
-    describe('with an invalid sytem number', () => {
+    describe('with a sytem number containing invalid characters', () => {
       before(() => {
         browser.search('invalid', '', '', '');
       });
@@ -137,6 +137,24 @@ describe('Search', () => {
 
       it('requests a number', () => {
         browser.getText('a').should.contain('Please enter a number');
+      });
+
+      it('shows the system number details hint', () => {
+        browser.isVisible('details > div').should.be.true;
+      });
+    });
+
+    describe('with a system number of an invalid length', () => {
+      before(() => {
+        browser.search('12345678', '', '', '');
+      });
+
+      it('displays an error message', () => {
+        browser.getText('h2').should.contain('Fix the following error');
+      });
+
+      it('requests a number of the valid length', () => {
+        browser.getText('a').should.contain('The system number should be 9 digits');
       });
 
       it('shows the system number details hint', () => {

--- a/test/unit/controllers/search.js
+++ b/test/unit/controllers/search.js
@@ -11,7 +11,7 @@ var formSubmission = function formSubmission(extension) {
     'forenames': '',
     'dob': ''
   }, extension);
-}
+};
 
 describe('controllers/search', function () {
   var api = {
@@ -64,19 +64,20 @@ describe('controllers/search', function () {
 
       describe('resolved promise', function() {
         it('redirects to the details page on one record returned', function() {
+          var sysnum = 123456789;
           var query = formSubmission({
-            'system-number': '1234'
+            'system-number': `${sysnum}`
           });
 
           req.query = query;
           api.read.withArgs(query).returns(Promise.resolve([{
-            'system-number': 1234
+            'system-number': sysnum
           }]));
 
           searchController(req, res);
 
           return Promise.resolve().then(function () {
-            res.redirect.should.have.been.calledWith('/details/1234?system-number=1234');
+            res.redirect.should.have.been.calledWith(`/details/${sysnum}?system-number=${sysnum}`);
           });
         });
 


### PR DESCRIPTION
A new validation rule has been added to check that system numbers are **9 digit numbers** as expected.

![image](https://cloud.githubusercontent.com/assets/7834222/17105946/35421a12-5281-11e6-9519-47098d4e8fc7.png)
