### PR TITLE
Update date of birth example

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -20,7 +20,7 @@
     },
     "dob": {
       "label": "Date of birth",
-      "hint": "For example, 18/2/2009"
+      "hint": "For example, 18/11/2009"
     }
   },
   "validation": {


### PR DESCRIPTION
Changed the example text for the date of birth field to a valid (and much more auspicious date)
![image](https://cloud.githubusercontent.com/assets/7834222/17334532/7e7a7ac8-58ce-11e6-8661-822c684efbdf.png)
