### PR TITLE
Disallow 1 and 3 digit years for date of birth

### DIFF
--- a/controllers/search.js
+++ b/controllers/search.js
@@ -13,13 +13,13 @@ var validators = Parent.validators;
 
 const britishDate = function britishDate(value) {
   return value === ''
-    || (this.regex(value, /^\d{1,2}\/\d{1,2}\/\d{1,4}$/) && moment(value, 'DD/MM/YYYY').isValid())
-    || (this.regex(value, /^\d{8}$/) && moment(value, 'DDMMYYYY').isValid());
+    || (this.regex(value, /^\d{1,2}\/\d{1,2}\/(?:\d\d){1,2}$/) && moment(value, 'DD/MM/YYYY').isValid())
+    || (this.regex(value, /^(?:\d\d){3,4}$/) && moment(value, 'DDMMYYYY').isValid());
 }.bind(validators);
 const past = value =>
-  value==='' || moment(value, /^\d{8}$/.test(value) ? 'DDMMYYYY' : 'DD/MM/YYYY').isBefore(moment().ceil(24, 'hours'));
+  value==='' || moment(value, /^\d{6,8}$/.test(value) ? 'DDMMYYYY' : 'DD/MM/YYYY').isBefore(moment().ceil(24, 'hours'));
 const since = (value, epoc) =>
-  value==='' || moment(value, /^\d{8}$/.test(value) ? 'DDMMYYYY' : 'DD/MM/YYYY').isSameOrAfter(moment(epoc).floor(24, 'hours'));
+  value==='' || moment(value, /^\d{6,8}$/.test(value) ? 'DDMMYYYY' : 'DD/MM/YYYY').isSameOrAfter(moment(epoc).floor(24, 'hours'));
 
 validators = _.extend(validators, {
   'british-date': britishDate,

--- a/test/unit/controllers/search.js
+++ b/test/unit/controllers/search.js
@@ -36,18 +36,24 @@ describe('controllers/search', function () {
       it('should accept properly formatted dates', () => {
         hof.validators['british-date']('31/12/1999').should.be.ok;
         hof.validators['british-date']('3/1/1999').should.be.ok;
-        hof.validators['british-date']('3/1/99').should.be.ok; // really!?
-        hof.validators['british-date']('1/1/1').should.be.ok; // really!? really!?
+        hof.validators['british-date']('3/1/99').should.be.ok;
       });
 
       it('should accept short format dates', () => {
         hof.validators['british-date']('31121999').should.be.ok;
         hof.validators['british-date']('03011999').should.be.ok;
       });
+      
+      it('should accept really short format dates', () => {
+        hof.validators['british-date']('311299').should.be.ok;
+        hof.validators['british-date']('030199').should.be.ok;
+      });
 
       it('should not accept improperly formatted dates', () => {
         hof.validators['british-date']('11/22/1999').should.not.be.ok;
         hof.validators['british-date']('3-1-99').should.not.be.ok;
+        hof.validators['british-date']('1/1/111').should.not.be.ok;
+        hof.validators['british-date']('1/1/1').should.not.be.ok;
       });
 
       it('should not accept short format dates without leading zeros', () => {


### PR DESCRIPTION
Only allow dates with the full 4 digit year, or the shorthand 2 digit format.
Valid date formats:
 - D/M/YY
 - D/M/YYYY
 - DDMMYY
 - DDMMYYYY