### PR TITLE
Change "jointly registered" to "registered by"

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -73,13 +73,13 @@ var processRecord = function processRecord(record) {
       occupation: record.subjects.father.occupation
     },
     registered: blocked ? {
-      jointly: 'UNAVAILABLE',
+      by: 'UNAVAILABLE',
       district: 'UNAVAILABLE',
       'sub-district': 'UNAVAILABLE',
       'admin-area': 'UNAVAILABLE',
       date: 'UNAVAILABLE'
     } : {
-      jointly: record.subjects.informant.qualification === 'Father, Mother' ? 'Yes' : 'No',
+      by: record.subjects.informant.qualification,
       district: record.location.registrationDistrict,
       'sub-district': record.location.subDistrict,
       'admin-area': record.location.administrativeArea,

--- a/test/acceptance/spec/20-details.js
+++ b/test/acceptance/spec/20-details.js
@@ -34,7 +34,7 @@ describe('Details Page', () => {
       browserText[11].should.match(new RegExp('Mother\'s Place of birth *' + recordToMatch.mother.birthplace));
       browserText[13].should.match(new RegExp('Father\'s Name *' + recordToMatch.father.name.fullName));
       browserText[14].should.match(new RegExp('Father\'s Place of birth *' + recordToMatch.father.birthplace));
-      browserText[16].should.match(new RegExp('Birth jointly registered *No'));
+      browserText[16].should.match(new RegExp('Birth registered by *Mother'));
       browserText[17].should.match(new RegExp('Registration district *' + recordToMatch.registrationDistrict));
       browserText[18].should.match(new RegExp('Sub-district *' + recordToMatch.subDistrict));
       browserText[19].should.match(new RegExp('Administrative area *' + recordToMatch.administrativeArea));

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -101,7 +101,7 @@ var parsedResponse = {
     occupation: 'Carpenter'
   },
   registered: {
-    jointly: 'No',
+    by: 'Mother',
     district: 'Manchester',
     'sub-district': 'Manchester',
     'admin-area': 'Metropolitan District of Manchester',
@@ -317,7 +317,7 @@ describe('api', function () {
               occupation: 'UNAVAILABLE'
             },
             registered: {
-              jointly: 'UNAVAILABLE',
+              by: 'UNAVAILABLE',
               district: 'UNAVAILABLE',
               'sub-district': 'UNAVAILABLE',
               'admin-area': 'UNAVAILABLE',
@@ -337,39 +337,19 @@ describe('api', function () {
       });
     });
 
-    describe('Jointly registered property', function () {
-      var promise;
+    describe('"Birth registered by" property', function () {
       var resp;
 
-      describe('when qualification is \'Father, Mother\'', function () {
-        beforeEach(function () {
-          resp = _.cloneDeep(response);
-          resp.subjects.informant.qualification = 'Father, Mother';
-          requestGet.yields(null, {statusCode: 200}, JSON.stringify(resp));
-          promise = api.requestID(1, 'mrs-caseworker');
-        });
-
-        it('is \'Yes\'', function () {
-          return promise.then(function (data) {
-            data.registered.jointly.should.eql('Yes');
-          });
-        });
+      beforeEach(function () {
+        resp = _.cloneDeep(response);
+        resp.subjects.informant.qualification = 'Father, Mother';
+        requestGet.yields(null, {statusCode: 200}, JSON.stringify(resp));
       });
 
-      describe('when qualification is NOT \'Father, Mother\'', function () {
-        beforeEach(function () {
-          resp = _.cloneDeep(response);
-          resp.subjects.informant.qualification = '-';
-          requestGet.yields(null, {statusCode: 200}, JSON.stringify(resp));
-          promise = api.requestID(1, 'mrs-caseworker');
-        });
-
-        it('is \'No\'', function () {
-          return promise.then(function (data) {
-            data.registered.jointly.should.eql('No');
-          });
-        });
-      });
+      it('should come from the API\'s "qualification" property', () =>
+        api.requestID(1, 'mrs-caseworker').should.eventually
+          .have.deep.property('registered.by', resp.subjects.informant.qualification)
+      );
     });
 
     describe('Flags', function () {

--- a/views/pages/details.html
+++ b/views/pages/details.html
@@ -106,8 +106,8 @@
         <th colspan="2">Registration</th>
       </tr>
       <tr>
-        <th>Birth jointly registered</th>
-        <td>{{record.registered.jointly}}</td>
+        <th>Birth registered by</th>
+        <td>{{record.registered.by}}</td>
       </tr>
       <tr>
         <th>Registration district</th>


### PR DESCRIPTION
The "Birth jointly registered" (values: "Yes"/"No") property of the details page has been changed to "Birth registered by" (values now come from the API/DB).