### PR TITLE
Improve system number hint accessibility

### DIFF
--- a/views/pages/search.html
+++ b/views/pages/search.html
@@ -32,7 +32,7 @@
           <img
             src="{{baseUrl}}/public/images/system-number-hint.png"
             alt="Where to find the system number on a birth certificate"
-            title="Where to find the system number on a birth certificate"
+            title="The system number is a nine digit number located in the bottom left corner of the birth certificate"
           />
         </div>
       </details>

--- a/views/pages/search.html
+++ b/views/pages/search.html
@@ -31,8 +31,8 @@
         <div class="panel panel-border-narrow">
           <img
             src="{{baseUrl}}/public/images/system-number-hint.png"
-            alt="Where to find the system number on a birth certificate"
-            title="The system number is a nine digit number located in the bottom left corner of the birth certificate"
+            alt="The system number is a nine digit number located in the bottom left corner of the birth certificate"
+            title="Where to find the system number on a birth certificate"
           />
         </div>
       </details>


### PR DESCRIPTION
Changed the `title` attribute of the system number hint image to describe the system number and define its location on a birth certificate.
![image](https://cloud.githubusercontent.com/assets/7834222/17593426/c1a37d5c-5fdd-11e6-8694-07dff9c4499e.png)
