### PR TITLE
Quick fix for logging out errors in JSON

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -18,23 +18,31 @@ var colors = {
 
 loggingTransports.push(
   new (winston.transports.Console)({
-    json: (notProd === true) ? false : true,
+    json: notProd !== true,
     timestamp: true,
     colorize: true,
     stringify: function stringify(obj) {
-      return JSON.stringify(obj);
+      const m = obj instanceof Error ? {
+        level: obj.level,
+        timestamp: obj.timestamp,
+        message: obj.toString(),
+        fileName: obj.fileName,
+        lineNumber: obj.lineNumber,
+        columnNumber: obj.columnNumber,
+        stack: obj.stack
+      } : obj;
+
+      return JSON.stringify(m);
     }
   })
 );
 
 exceptionTransports.push(
   new (winston.transports.Console)({
-    json: (notProd === true) ? false : true,
+    json: notProd !== true,
     timestamp: true,
     colorize: true,
-    stringify: function stringify(obj) {
-      return JSON.stringify(obj);
-    }
+    stringify: JSON.stringify
   })
 );
 


### PR DESCRIPTION
I don't think this is the solution in the long run. I think we should either use hmpo-logger or write our own.