### PR TITLE
Pin to last working version of http-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-mocha": "^4.5.0",
     "eslint-plugin-one-variable-per-var": "0.0.3",
     "express-hijackresponse": "^0.2.1",
-    "http-proxy": "^1.12.0",
+    "http-proxy": "~1.14.0",
     "istanbul": "^0.4.3",
     "jscs": "^3.0.2",
     "mocha": "^3.0.2",


### PR DESCRIPTION
Pins http-proxy to the last working version in order to avoid a bug that
breaks our acceptance tests.