### PR TITLE
Add kubernetes management endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,9 @@ if (config.env !== 'acceptance') {
   app.use(churchill(logger));
 }
 
+// add health check endpoints
+app.use(require('./lib/health'));
+
 app.use('/public', express.static(path.resolve(__dirname, './public')));
 
 app.use(function setAssetPath(req, res, next) {

--- a/lib/health.js
+++ b/lib/health.js
@@ -2,12 +2,8 @@
 
 const route = require('express').Router();
 
-const respond = (req, res, next) => {
-  if (req.ip === '127.0.0.1' || req.ip === 'localhost') {
-    res.send('OK');
-  } else {
-    next();
-  }
+const respond = (req, res) => {
+  res.send('OK');
 };
 
 route.get('/healthz', respond);

--- a/lib/health.js
+++ b/lib/health.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const route = require('express').Router();
+
+const respond = (req, res, next) => {
+  if (req.ip === '127.0.0.1' || req.ip === 'localhost') {
+    res.send('OK');
+  } else {
+    next();
+  }
+};
+
+route.get('/healthz', respond);
+route.get('/readiness', respond);
+
+module.exports = route;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "mocha": "^3.0.2",
     "proxyquire": "^1.7.3",
     "reqres": "^1.2.2",
+    "rewire": "^2.5.2",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },

--- a/test/acceptance/spec/02-health.js
+++ b/test/acceptance/spec/02-health.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const request = require('request');
+const url = require('../config').url;
+
+describe('Health check', () => {
+  let result;
+
+  const makeRequest = (path, done) => {
+    request.get(url + path, (err, response) => {
+      result = response;
+      done(err);
+    });
+  };
+
+  describe('the "/healthz" endpoint', () => {
+    before(done => {
+      makeRequest('healthz', done);
+    });
+
+    it('should return a "200 - OK" status', () => {
+      expect(result.statusCode).to.equal(200);
+    });
+  });
+
+  describe('the "/readiness" endpoint', () => {
+    before(done => {
+      makeRequest('readiness', done);
+    });
+
+    it('should return a "200 - OK" status', () => {
+      expect(result.statusCode).to.equal(200);
+    });
+  });
+});

--- a/test/unit/lib/health.js
+++ b/test/unit/lib/health.js
@@ -15,22 +15,12 @@ describe('Health check endpoints', () => {
     res = reqres.res();
   });
 
-  it('should respond with 200 - OK to local requests', done => {
-    req.ip = '127.0.0.1';
+  it('should respond with 200 - OK to all requests', done => {
     fn(req, res, err => {
       done(err || new Error('next function should not be called!'));
     });
     res.on('end', () => {
       expect(res.send).to.have.been.calledWith('OK');
-      done();
-    });
-  });
-
-  it('should do nothing when the request is not from localhost', done => {
-    req.ip = '1.1.1.1';
-    fn(req, res, err => {
-      expect(err).to.equal(undefined);
-      expect(res.send).not.to.have.been.called;
       done();
     });
   });

--- a/test/unit/lib/health.js
+++ b/test/unit/lib/health.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const rewire = require('rewire');
+const reqres = require('reqres');
+
+const health = rewire('../../../lib/health');
+const fn = health.__get__('respond'); // eslint-disable-line no-underscore-dangle
+
+describe('Health check endpoints', () => {
+  var req;
+  var res;
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+  });
+
+  it('should respond with 200 - OK to local requests', done => {
+    req.ip = '127.0.0.1';
+    fn(req, res, err => {
+      done(err || new Error('next function should not be called!'));
+    });
+    res.on('end', () => {
+      expect(res.send).to.have.been.calledWith('OK');
+      done();
+    });
+  });
+
+  it('should do nothing when the request is not from localhost', done => {
+    req.ip = '1.1.1.1';
+    fn(req, res, err => {
+      expect(err).to.equal(undefined);
+      expect(res.send).not.to.have.been.called;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Add the `healthz` and `readiness` endpoints used by Kubernetes management probes.