### PR TITLE
LEVWEB-677 Automate common dev tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "stop:mockapi": "npm-run-all -c --silent stop:mockapi:kill stop:mockapi:rm",
     "stop:mockapi:kill": "docker kill lev-api-mock || true",
     "stop:mockapi:rm": "docker rm lev-api-mock || true",
-    "stop:mock-kc-proxy": "killall lev-keycloak-proxy",
+    "stop:mock-kc-proxy": "killall lev-keycloak-proxy || true",
     "stop:all": "npm-run-all -c stop:mockapi stop:mock-kc-proxy stop",
     "chimp": "NODE_ENV=acceptance chimp --mocha --browser=phantomjs --path=./test/acceptance/spec/",
     "chimp:ff": "NODE_ENV=acceptance chimp --mocha --browser=firefox --path=./test/acceptance/spec/ --watch",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node .",
     "stop": "pkill levweb || true",
     "dev": "npm-run-all -pr start:mock-kc-proxy start:dev",
+    "dev:backend": "npm-run-all -p start:mock-kc-proxy start:dev start:mockapi watch:unit",
     "test": "npm-run-all lint cover check-coverage test:acceptance",
     "test:unit": "NODE_ENV=test mocha ./test/unit",
     "watch:unit": "nodemon -w './*.js' -w routes -w middleware -w locales -w lib -w fields -w controllers -w api -w test/unit -x 'npm-run-all -s lint cover'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node .",
     "stop": "pkill levweb || true",
-    "dev": "npm-run-all -pr start:mock-kc-proxy start:dev",
+    "dev": "npm-run-all -s stop:all dev:up",
     "dev:up": "npm-run-all -p dev:frontend dev:backend",
     "dev:frontend": "npm-run-all -p watch:sass watch:js",
     "dev:backend": "npm-run-all -p start:mock-kc-proxy start:dev start:mockapi watch:unit",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:ci": "npm-run-all lint cover check-coverage ci:acceptance",
     "ci:acceptance": "npm-run-all -pr start:mock-kc-proxy chimp",
     "start:acceptance": "NODE_ENV=acceptance npm start",
-    "start:dev": "NODE_ENV=development nodemon .",
+    "start:dev": "NODE_ENV=development nodemon -w './*.js' -w routes -w middleware -w locales -w lib -w fields -w controllers -w api .",
     "start:mockapi": "docker run -d -p 8080:8080 --name lev-api-mock quay.io/ukhomeofficedigital/lev-api-mock:v1.2.1-117-0978aa84d33711118362d15a7a5cc2d5b37c908e",
     "start:mock-kc-proxy": "node test/acceptance/mock-kc-proxy/front.js",
     "stop:mockapi": "npm-run-all -c --silent stop:mockapi:kill stop:mockapi:rm",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "stop:all": "npm-run-all -c stop:mockapi stop:mock-kc-proxy stop",
     "chimp": "NODE_ENV=acceptance chimp --mocha --browser=phantomjs --path=./test/acceptance/spec/",
     "chimp:ff": "NODE_ENV=acceptance chimp --mocha --browser=firefox --path=./test/acceptance/spec/ --watch",
+    "watch:chimp": "nodemon -w ./test/acceptance -x 'npm run chimp'",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "cover": "istanbul cover _mocha -- ./test/unit",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "stop": "pkill levweb || true",
     "dev": "npm-run-all -s stop:all dev:up",
     "dev:up": "npm-run-all -p dev:frontend dev:backend",
-    "dev:frontend": "npm-run-all -p watch:sass watch:js",
+    "dev:frontend": "npm-run-all -p watch:sass watch:js watch:chimp",
     "dev:backend": "npm-run-all -p start:mock-kc-proxy start:dev start:mockapi watch:unit",
     "test": "npm-run-all lint cover check-coverage test:acceptance",
     "test:unit": "NODE_ENV=test mocha ./test/unit",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cover": "istanbul cover _mocha -- ./test/unit",
     "check-coverage": "istanbul check-coverage --statement 95 --branch 85 --function 100 --line 95",
     "sass": "node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
+    "watch:sass": "nodemon -w assets/scss -e '.scss' -x 'npm run sass'",
     "copy:images": "cp -r ./assets/images ./public/",
     "uglify": "browserify -g uglifyify ./assets/js/index.js > ./public/js/bundle.js",
     "watch:js": "nodemon -w assets/js -x 'npm-run-all -s lint:client uglify'",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node .",
     "stop": "pkill levweb || true",
     "dev": "npm-run-all -pr start:mock-kc-proxy start:dev",
+    "dev:up": "npm-run-all -p dev:frontend dev:backend",
     "dev:frontend": "npm-run-all -p watch:sass watch:js",
     "dev:backend": "npm-run-all -p start:mock-kc-proxy start:dev start:mockapi watch:unit",
     "test": "npm-run-all lint cover check-coverage test:acceptance",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "npm-run-all -pr start:mock-kc-proxy start:dev",
     "test": "npm-run-all lint cover check-coverage test:acceptance",
     "test:unit": "NODE_ENV=test mocha ./test/unit",
+    "watch:unit": "nodemon -w './*.js' -w routes -w middleware -w locales -w lib -w fields -w controllers -w api -w test/unit -x 'npm-run-all -s lint cover'",
     "test:acceptance": "npm-run-all stop:mockapi start:mockapi test:acceptance:sub stop:mockapi",
     "test:acceptance:sub": "npm-run-all -pr start:mock-kc-proxy start:acceptance chimp",
     "test:ci": "npm-run-all lint cover check-coverage ci:acceptance",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "sass": "node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
     "copy:images": "cp -r ./assets/images ./public/",
     "uglify": "browserify -g uglifyify ./assets/js/index.js > ./public/js/bundle.js",
+    "watch:js": "nodemon -w assets/js -x 'npm-run-all -s lint:client uglify'",
     "browserify": "browserify ./assets/js/index.js > ./public/js/bundle.js",
     "create:public": "mkdir -p ./public/css ./public/images ./public/js",
     "postinstall": "npm-run-all create:public sass copy:images uglify",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "watch:chimp": "nodemon -w ./test/acceptance -x 'npm run chimp'",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "lint:client": "eslint ./assets/js",
     "cover": "istanbul cover _mocha -- ./test/unit",
     "check-coverage": "istanbul check-coverage --statement 95 --branch 85 --function 100 --line 95",
     "sass": "node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node .",
-    "stop": "pkill levweb",
+    "stop": "pkill levweb || true",
     "dev": "npm-run-all -pr start:mock-kc-proxy start:dev",
     "test": "npm-run-all lint cover check-coverage test:acceptance",
     "test:unit": "NODE_ENV=test mocha ./test/unit",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node .",
     "stop": "pkill levweb || true",
     "dev": "npm-run-all -pr start:mock-kc-proxy start:dev",
+    "dev:frontend": "npm-run-all -p watch:sass watch:js",
     "dev:backend": "npm-run-all -p start:mock-kc-proxy start:dev start:mockapi watch:unit",
     "test": "npm-run-all lint cover check-coverage test:acceptance",
     "test:unit": "NODE_ENV=test mocha ./test/unit",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start:dev": "NODE_ENV=development nodemon -w './*.js' -w routes -w middleware -w locales -w lib -w fields -w controllers -w api .",
     "start:mockapi": "docker run -d -p 8080:8080 --name lev-api-mock quay.io/ukhomeofficedigital/lev-api-mock:v1.2.1-117-0978aa84d33711118362d15a7a5cc2d5b37c908e",
     "start:mock-kc-proxy": "node test/acceptance/mock-kc-proxy/front.js",
-    "stop:mockapi": "npm-run-all -c --silent stop:mockapi:kill stop:mockapi:rm",
+    "stop:mockapi": "npm-run-all -s -c --silent stop:mockapi:kill stop:mockapi:rm",
     "stop:mockapi:kill": "docker kill lev-api-mock || true",
     "stop:mockapi:rm": "docker rm lev-api-mock || true",
     "stop:mock-kc-proxy": "killall lev-keycloak-proxy || true",


### PR DESCRIPTION
Improve the development workflow so that `npm run dev` now automatically does:
 - the SASS compilation when the styles are updated
 - the linting and uglification of the frontend JS when the client code changes
 - linting and unit testing when the app code or unit test code changes
 - end-to-end tests run when the test code changes

Plus, manual tests can be run in the browser.

NOTE: Manual and end-to-end tests will be hitting the mock API.