### PR TITLE
LEVWEB-638 Add audit user filter

### DIFF
--- a/api/helpers.js
+++ b/api/helpers.js
@@ -21,12 +21,12 @@ const buildBirthParams = (attrs) => _.pickBy({
   lastname: attrs.surname,
   forenames: attrs.forenames,
   dateofbirth: attrs.dob && toInternationalDateFormat(attrs.dob)
-});
+}, _.identity);
 const buildAuditParams = (attrs) => _.pickBy({
   from: toInternationalDateFormat(attrs.from),
   to: toInternationalDateFormat(attrs.to),
   user: attrs.user
-});
+}, _.identity);
 const buildQueryUri = (endpoint, attrs) => {
   if (!attrs) {
     return endpoint;

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -22,9 +22,10 @@ const buildBirthParams = (attrs) => _.pickBy({
   forenames: attrs.forenames,
   dateofbirth: attrs.dob && toInternationalDateFormat(attrs.dob)
 });
-const buildAuditParams = (attrs) => ({
+const buildAuditParams = (attrs) => _.pickBy({
   from: toInternationalDateFormat(attrs.from),
-  to: toInternationalDateFormat(attrs.to)
+  to: toInternationalDateFormat(attrs.to),
+  user: attrs.user
 });
 const buildQueryUri = (endpoint, attrs) => {
   if (!attrs) {

--- a/api/index.js
+++ b/api/index.js
@@ -79,7 +79,13 @@ const findBirths = (searchFields, user) => {
     : findByNameDOB(searchFields, user);
 };
 
-const userActivityReport = (from, to, user) => {
+const userActivityReport = (user, from, to) => {
+  if (!user) {
+    throw new ReferenceError('The "user" parameter was not provided');
+  }
+  if (typeof user !== 'string') {
+    throw new TypeError('The "user" parameter must be a string');
+  }
   if (!from || !to) {
     throw new ReferenceError('"from" and "to" dates must be provided for the User Activity report');
   }
@@ -87,13 +93,10 @@ const userActivityReport = (from, to, user) => {
     throw new TypeError('"from" and "to" dates for the User Activity report must be Moment objects');
   }
   if (!from.isValid() || !to.isValid()) {
-    throw new RangeError('"from" and "to" dates for the User Activity report must be Moment objects');
+    throw new RangeError('"from" and "to" dates for the User Activity report must be valid dates');
   }
   if (from.isAfter(to)) {
     throw new RangeError('"from" date must be before "to" date for the User Activity report');
-  }
-  if (!user || typeof user !== 'string') {
-    throw new TypeError('The "user" parameter was not provided');
   }
 
   return requestData(helpers.buildQueryUri(userActivity, { from: from, to: to }), user);

--- a/api/index.js
+++ b/api/index.js
@@ -79,7 +79,7 @@ const findBirths = (searchFields, user) => {
     : findByNameDOB(searchFields, user);
 };
 
-const userActivityReport = (user, from, to) => {
+const userActivityReport = (user, from, to, userFilter) => {
   if (!user) {
     throw new ReferenceError('The "user" parameter was not provided');
   }
@@ -99,7 +99,13 @@ const userActivityReport = (user, from, to) => {
     throw new RangeError('"from" date must be before "to" date for the User Activity report');
   }
 
-  return requestData(helpers.buildQueryUri(userActivity, { from: from, to: to }), user);
+  const data = {
+    from: from,
+    to: to,
+    user: userFilter
+  };
+
+  return requestData(helpers.buildQueryUri(userActivity, data), user);
 };
 
 module.exports = {

--- a/controllers/audit.js
+++ b/controllers/audit.js
@@ -72,8 +72,6 @@ AuditController.prototype.successHandler = function successHandler(req, res, cal
   const to = validators.parseDate(req.form.values.to).floor(24, 'hours');
   const toInclusive = moment(to).add(1, 'day');
   const userFilter = req.form.values.user;
-  // eslint-disable-next-line no-warning-comments
-  // const roles = req.headers['X-Auth-Roles'] || req.headers['x-auth-roles']; // TODO: check for auditor role???
 
   const resolved = (records) => {
     const data = {

--- a/controllers/audit.js
+++ b/controllers/audit.js
@@ -71,6 +71,7 @@ AuditController.prototype.successHandler = function successHandler(req, res, cal
   const from = validators.parseDate(req.form.values.from).floor(24, 'hours');
   const to = validators.parseDate(req.form.values.to).floor(24, 'hours');
   const toInclusive = moment(to).add(1, 'day');
+  const userFilter = req.form.values.user;
   // eslint-disable-next-line no-warning-comments
   // const roles = req.headers['X-Auth-Roles'] || req.headers['x-auth-roles']; // TODO: check for auditor role???
 
@@ -79,6 +80,9 @@ AuditController.prototype.successHandler = function successHandler(req, res, cal
       from: from.format('DD/MM/YYYY'),
       to: to.format('DD/MM/YYYY')
     };
+    if (userFilter) {
+      data.user = userFilter;
+    }
     if (records && Object.keys(records).length) {
       const days = daysInDateRange(from, toInclusive);
       const usage = expandUsers(records, days);
@@ -97,7 +101,7 @@ AuditController.prototype.successHandler = function successHandler(req, res, cal
     callback(error, req, res);
   };
 
-  api.userActivityReport(username, from, toInclusive).then(resolved, rejected);
+  api.userActivityReport(username, from, toInclusive, userFilter).then(resolved, rejected);
 };
 
 const form = new AuditController({

--- a/controllers/audit.js
+++ b/controllers/audit.js
@@ -97,7 +97,7 @@ AuditController.prototype.successHandler = function successHandler(req, res, cal
     callback(error, req, res);
   };
 
-  api.userActivityReport(from, toInclusive, username).then(resolved, rejected);
+  api.userActivityReport(username, from, toInclusive).then(resolved, rejected);
 };
 
 const form = new AuditController({

--- a/controllers/audit.js
+++ b/controllers/audit.js
@@ -76,11 +76,9 @@ AuditController.prototype.successHandler = function successHandler(req, res, cal
   const resolved = (records) => {
     const data = {
       from: from.format('DD/MM/YYYY'),
-      to: to.format('DD/MM/YYYY')
+      to: to.format('DD/MM/YYYY'),
+      user: userFilter
     };
-    if (userFilter) {
-      data.user = userFilter;
-    }
     if (records && Object.keys(records).length) {
       const days = daysInDateRange(from, toInclusive);
       const usage = expandUsers(records, days);

--- a/fields/audit.js
+++ b/fields/audit.js
@@ -6,5 +6,8 @@ module.exports = {
   },
   'to': {
     validate: ['british-date', 'required']
+  },
+  user: {
+    validate: ['email-chars']
   }
 };

--- a/lib/custom-validators.js
+++ b/lib/custom-validators.js
@@ -18,10 +18,15 @@ const past = value => value === ''
 const since = (value, epoc) => value === ''
   || moment(value, /^\d{6,8}$/.test(value) ? 'DDMMYYYY' : 'DD/MM/YYYY').isSameOrAfter(moment(epoc).floor(24, 'hours'));
 
+const emailChars = function emailChars(value) {
+  return value === '' || this.regex(value, /^[a-z0-9._%+@-]+$/i);
+};
+
 const addValidators = validators => _.extend(validators, {
   'british-date': britishDate.bind(validators),
   'past': past,
-  'since': since
+  'since': since,
+  'email-chars': emailChars.bind(validators)
 });
 
 module.exports = {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -29,6 +29,10 @@
     "to": {
       "label": "Search to",
       "hint": "For example 15/1/2017"
+    },
+    "user": {
+      "label": "User filter",
+      "hint": "For example 'bob@hmpo.gov.uk' for a use, or 'hmrc' for a group of users"
     }
   },
   "validation": {
@@ -57,6 +61,9 @@
     "to": {
       "required": "Please enter a date to search up to",
       "british-date": "Please enter the \"to\" date in the correct format"
+    },
+    "user": {
+      "email-chars": "Please only use characters that can be used for an email address: a-z, A-Z, 0-9, or '_%-@.'"
     }
   },
   "flags": {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -32,7 +32,7 @@
     },
     "user": {
       "label": "User filter",
-      "hint": "For example 'bob@hmpo.gov.uk' for a use, or 'hmrc' for a group of users"
+      "hint": "For example 'bob@hmpo.gov.uk' for a single user, or '@hmrc.gov.uk' for a group of users"
     }
   },
   "validation": {

--- a/test/acceptance/mixins/audit.js
+++ b/test/acceptance/mixins/audit.js
@@ -4,9 +4,9 @@ const url = require('../config').url;
 const userActivity = `${url}/audit/user-activity`;
 
 module.exports = (target) => {
-  target.generateReport = function(from, to) {
+  target.generateReport = function(from, to, user) {
     this.goToUserActivityReport();
-    this.submitUserActivityReport(from, to);
+    this.submitUserActivityReport(from, to, user);
   };
 
   target.goToUserActivityReport = function() {
@@ -22,9 +22,12 @@ module.exports = (target) => {
     formLabels[1].should.match(/^Search to/);
   };
 
-  target.submitUserActivityReport = function(from, to) {
+  target.submitUserActivityReport = function(from, to, user) {
     this.setValue('input[name="from"]', from);
     this.setValue('input[name="to"]', to);
+    if (user) {
+      this.setValue('input[name="user"]', user);
+    }
     this.submitForm('form');
   };
 };

--- a/test/acceptance/spec/23-user-activity.js
+++ b/test/acceptance/spec/23-user-activity.js
@@ -159,7 +159,6 @@ describe('User Activity', () => {
       const from = '23/12/2016';
       const to = '26/12/2016';
       const user = 'lev-e2e-tests';
-      let rowHeaders;
 
       before(() => {
         browser.generateReport(from, to, user);
@@ -172,10 +171,15 @@ describe('User Activity', () => {
       it('displays an appropriate message including the user filter value', () => {
         const h2 = `Showing audit data for '${user}' from ${from}, to ${to}`;
         browser.getText('h2').should.equal(h2);
-        rowHeaders = browser.getText('table.audit > tbody > tr > th');
       });
 
       describe('displays the search count table', () => {
+        let rowHeaders;
+
+        before('get the row headers', () => {
+          rowHeaders = browser.getText('table.audit > tbody > tr > th');
+        });
+
         it('with two rows only', () => {
           rowHeaders.length.should.equal(2);
         });

--- a/test/unit/api/helpers.js
+++ b/test/unit/api/helpers.js
@@ -202,6 +202,27 @@ describe('api/helpers.js', () => {
         to: '2010-01-13'
       });
     });
+    it('should not add an empty user filter value', () => {
+      expect(buildAuditParams({
+        from: moment('31/01/2010', 'DD/MM/YYYY'),
+        to: moment('13/01/2010', 'DD/MM/YYYY'),
+        user: ''
+      })).to.deep.equal({
+        from: '2010-01-31',
+        to: '2010-01-13'
+      });
+    });
+    it('should add a non empty user filter value', () => {
+      expect(buildAuditParams({
+        from: moment('31/01/2010', 'DD/MM/YYYY'),
+        to: moment('13/01/2010', 'DD/MM/YYYY'),
+        user: 'chuck'
+      })).to.deep.equal({
+        from: '2010-01-31',
+        to: '2010-01-13',
+        user: 'chuck'
+      });
+    });
   });
 
   describe('buildQueryUri', () => {

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -641,5 +641,32 @@ describe('api/index.js', () => {
         });
       });
     });
+
+    describe('when called with a user filter', () => {
+      let result;
+      const from = '2001-03-01';
+      const to = '2001-04-01';
+      const user = 'an-auditor';
+
+      before('try to get the user activity data', () => {
+        this.resetStubs = false;
+        result = api.userActivityReport(user, moment(from), moment(to), 'fred');
+      });
+
+      it('should make a request to the API', () =>
+        requestGet.lastCall.should.have.been.calledWith({
+          headers: {
+            Authorization: 'Bearer access_token',
+            'X-Auth-Downstream-Username': user
+          },
+          url: `http://testhost.com:1111/api/v0/audit/user-activity?from=${from}&to=${to}&user=fred`
+        }));
+
+      it('then return a promise', () => result.should.be.instanceOf(Promise));
+
+      after(() => {
+        this.resetStubs = true;
+      });
+    });
   });
 });

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -634,7 +634,7 @@ describe('api/index.js', () => {
             url: `http://testhost.com:1111/api/v0/audit/user-activity?from=${from}&to=${to}`
           }));
 
-        it('then return a promise', () => result.should.be.instanceOf(Promise));
+        it('returns a promise', () => result.should.be.instanceOf(Promise));
 
         after(() => {
           this.resetStubs = true;
@@ -662,7 +662,7 @@ describe('api/index.js', () => {
           url: `http://testhost.com:1111/api/v0/audit/user-activity?from=${from}&to=${to}&user=fred`
         }));
 
-      it('then return a promise', () => result.should.be.instanceOf(Promise));
+      it('returns a promise', () => result.should.be.instanceOf(Promise));
 
       after(() => {
         this.resetStubs = true;

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -584,32 +584,35 @@ describe('api/index.js', () => {
       expect(api.userActivityReport).to.throw(ReferenceError);
     });
 
+    describe('when called with an invalid system user', () => {
+      it('should throw a ReferenceError if the `user` parameter is not specified', () =>
+        expect(() => api.userActivityReport(undefined, moment().add(-1, 'days'), moment())).to.throw(ReferenceError)
+      );
+      it('should throw a TypeError if the `user` parameter is not a proper string', () => {
+        expect(() => api.userActivityReport(null, moment().add(-1, 'days'), moment())).to.throw(ReferenceError);
+        expect(() => api.userActivityReport(42, moment().add(-1, 'days'), moment())).to.throw(TypeError);
+      });
+    });
+
     describe('when called without the required `from` or `to` dates', () => {
       it('should throw a ReferenceError if either parameter is omitted', () => {
-        expect(from => api.userActivityReport(from, moment())).to.throw(ReferenceError);
-        expect(() => api.userActivityReport(moment())).to.throw(ReferenceError);
+        expect(from => api.userActivityReport('user', from, moment())).to.throw(ReferenceError);
+        expect(() => api.userActivityReport('user', moment())).to.throw(ReferenceError);
       });
       it('should throw a ReferenceError if either parameter is not a `moment` date object', () => {
-        expect(() => api.userActivityReport('from', moment())).to.throw(TypeError);
-        expect(() => api.userActivityReport(moment(), 'to')).to.throw(TypeError);
+        expect(() => api.userActivityReport('user', 'from', moment())).to.throw(TypeError);
+        expect(() => api.userActivityReport('user', moment(), 'to')).to.throw(TypeError);
       });
       it('should throw a ReferenceError if either parameter is not a valid date object', () => {
-        expect(() => api.userActivityReport(moment('from'), moment())).to.throw(RangeError);
-        expect(() => api.userActivityReport(moment(), moment('2017-02-29'))).to.throw(RangeError);
+        expect(() => api.userActivityReport('user', moment('from'), moment())).to.throw(RangeError);
+        expect(() => api.userActivityReport('user', moment(), moment('2017-02-29'))).to.throw(RangeError);
       });
     });
 
     describe('when called with valid dates', () => {
       it('should throw a RangeError if the `to` date is before `from`', () =>
-        expect(() => api.userActivityReport(moment().add(1, 'days'), moment())).to.throw(RangeError)
+        expect(() => api.userActivityReport('user', moment().add(1, 'days'), moment())).to.throw(RangeError)
       );
-      it('should throw a TypeError if the `user` parameter is not specified', () =>
-        expect(() => api.userActivityReport(moment().add(-1, 'days'), moment())).to.throw(TypeError)
-      );
-      it('should throw a TypeError if the `user` parameter is not a proper string', () => {
-        expect(() => api.userActivityReport(moment().add(-1, 'days'), moment(), null)).to.throw(TypeError);
-        expect(() => api.userActivityReport(moment().add(-1, 'days'), moment(), '')).to.throw(TypeError);
-      });
 
       describe('as a proper range', () => {
         let result;
@@ -619,7 +622,7 @@ describe('api/index.js', () => {
 
         before('try to get the user activity data', () => {
           this.resetStubs = false;
-          result = api.userActivityReport(moment(from), moment(to), user);
+          result = api.userActivityReport(user, moment(from), moment(to));
         });
 
         it('should make a request to the API', () =>

--- a/test/unit/controllers/audit.js
+++ b/test/unit/controllers/audit.js
@@ -89,7 +89,8 @@ describe('Audit Controller', () => {
                 data.should.deep.equal({
                   from: req.query.from,
                   to: req.query.to,
-                  naudit: true
+                  naudit: true,
+                  user: ''
                 });
                 done();
               } catch (err) {
@@ -152,6 +153,7 @@ describe('Audit Controller', () => {
                 data.should.deep.equal({
                   from: req.query.from,
                   to: req.query.to,
+                  user: '',
                   audit: {
                     dates: [
                       { classes: '', date: '2017-02-02', day: '2', month: 'Feb', year: '2017' },

--- a/test/unit/controllers/audit.js
+++ b/test/unit/controllers/audit.js
@@ -79,7 +79,7 @@ describe('Audit Controller', () => {
           const toAdjusted = '02/01/1900';
           const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
           const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
-          api.userActivityReport.withArgs(matchFrom, matchTo).returns(Promise.resolve({}));
+          api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.resolve({}));
 
           res.render = (view, data) => {
             try {
@@ -110,7 +110,7 @@ describe('Audit Controller', () => {
           const toAdjusted = '04/02/2017';
           const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
           const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
-          api.userActivityReport.withArgs(matchFrom, matchTo).returns(Promise.resolve(records));
+          api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.resolve(records));
 
           res.render = (view, data) => {
             try {
@@ -152,7 +152,7 @@ describe('Audit Controller', () => {
           const toAdjusted = '16/01/2016';
           const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
           const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
-          api.userActivityReport.withArgs(matchFrom, matchTo).returns(Promise.reject(err));
+          api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.reject(err));
 
           const next = (error) => {
             try {
@@ -175,7 +175,7 @@ describe('Audit Controller', () => {
           const toAdjusted = '21/01/2009';
           const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
           const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
-          api.userActivityReport.withArgs(matchFrom, matchTo).returns(Promise.reject(err.message));
+          api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.reject(err.message));
 
           const next = (error) => {
             try {

--- a/test/unit/controllers/audit.js
+++ b/test/unit/controllers/audit.js
@@ -59,84 +59,148 @@ describe('Audit Controller', () => {
 
     describe('when there is a query string', () => {
       let req;
+      const loggedOnUser = 'mrs-caseworker';
 
       beforeEach(() => {
         req = _.extend(reqres.req(), {
           body: undefined,
           headers: {
-            'X-Auth-Username': 'mrs-caseworker'
+            'X-Auth-Username': loggedOnUser
           },
           method: 'GET'
         });
       });
 
       describe('the resolved promise', () => {
-        it('shows a special message if there is no data available', (done) => {
-          req.query = {
-            from: '01/01/1800',
-            to: '01/01/1900'
-          };
-          const toAdjusted = '02/01/1900';
-          const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
-          const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
-          api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.resolve({}));
+        describe('renders a special page when no data is found', () => {
+          it('with the search dates displayed', (done) => {
+            req.query = {
+              from: '01/01/1800',
+              to: '01/01/1900'
+            };
+            const toAdjusted = '02/01/1900';
+            const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
+            const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
+            api.userActivityReport.withArgs(loggedOnUser, matchFrom, matchTo).returns(Promise.resolve({}));
 
-          res.render = (view, data) => {
-            try {
-              view.should.equal('pages/user-activity');
-              data.should.deep.equal({
-                from: req.query.from,
-                to: req.query.to,
-                naudit: true
-              });
-              done();
-            } catch (err) {
-              done(err);
-            }
-          };
+            res.render = (view, data) => {
+              try {
+                view.should.equal('pages/user-activity');
+                data.should.deep.equal({
+                  from: req.query.from,
+                  to: req.query.to,
+                  naudit: true
+                });
+                done();
+              } catch (err) {
+                done(err);
+              }
+            };
 
-          controller(req, res);
+            controller(req, res);
+          });
+
+          it('and displays the user search value', (done) => {
+            req.query = {
+              from: '02/03/1800',
+              to: '02/03/1900',
+              user: 'mr_user'
+            };
+            const toAdjusted = '03/03/1900';
+            const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
+            const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
+            api.userActivityReport.withArgs(loggedOnUser, matchFrom, matchTo, req.query.user)
+              .returns(Promise.resolve({}));
+
+            res.render = (view, data) => {
+              try {
+                view.should.equal('pages/user-activity');
+                data.should.deep.equal({
+                  from: req.query.from,
+                  to: req.query.to,
+                  user: req.query.user,
+                  naudit: true
+                });
+                done();
+              } catch (err) {
+                done(err);
+              }
+            };
+
+            controller(req, res);
+          });
         });
 
-        it('renders the report table', (done) => {
-          const records = {
-            amanda: { '2017-02-02': 3 },
-            colin: { '2017-02-03': 7 }
-          };
-          req.query = {
-            from: '02/02/2017',
-            to: '03/02/2017'
-          };
-          const toAdjusted = '04/02/2017';
-          const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
-          const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
-          api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.resolve(records));
+        describe('otherwise renders the report table', () => {
+          it('including a message with the dates', (done) => {
+            const records = {
+              amanda: { '2017-02-02': 3 },
+              colin: { '2017-02-03': 7 }
+            };
+            req.query = {
+              from: '02/02/2017',
+              to: '03/02/2017'
+            };
+            const toAdjusted = '04/02/2017';
+            const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
+            const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
+            api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo).returns(Promise.resolve(records));
 
-          res.render = (view, data) => {
-            try {
-              view.should.equal('pages/user-activity');
-              data.should.deep.equal({
-                from: req.query.from,
-                to: req.query.to,
-                audit: {
-                  dates: [
-                    { classes: '', date: '2017-02-02', day: '2', month: 'Feb', year: '2017' },
-                    { classes: '', date: '2017-02-03', day: '3', month: 'Feb', year: '2017' }
-                  ],
-                  usage: [ /* eslint-disable no-multi-spaces */
-                    { user: 'amanda',     searches: [{ count: 3    }, { count: null }, { count: 3  }] },
-                    { user: 'colin',      searches: [{ count: null }, { count: 7    }, { count: 7  }] },
-                    { user: 'Day totals', searches: [{ count: 3    }, { count: 7    }, { count: 10 }] }
-                  ] /* eslint-enable no-multi-spaces */
-                }
-              });
-              done();
-            } catch (err) {
-              done(err);
-            }
-          };
+            res.render = (view, data) => {
+              try {
+                view.should.equal('pages/user-activity');
+                data.should.deep.equal({
+                  from: req.query.from,
+                  to: req.query.to,
+                  audit: {
+                    dates: [
+                      { classes: '', date: '2017-02-02', day: '2', month: 'Feb', year: '2017' },
+                      { classes: '', date: '2017-02-03', day: '3', month: 'Feb', year: '2017' }
+                    ],
+                    usage: [ /* eslint-disable no-multi-spaces */
+                      { user: 'amanda',     searches: [{ count: 3    }, { count: null }, { count: 3  }] },
+                      { user: 'colin',      searches: [{ count: null }, { count: 7    }, { count: 7  }] },
+                      { user: 'Day totals', searches: [{ count: 3    }, { count: 7    }, { count: 10 }] }
+                    ] /* eslint-enable no-multi-spaces */
+                  }
+                });
+                done();
+              } catch (err) {
+                done(err);
+              }
+            };
 
-          controller(req, res);
+            controller(req, res);
+          });
+
+          it('and displays the user search value', (done) => {
+            const records = {
+              amanda: { '2017-02-02': 3 },
+              colin: { '2017-02-03': 7 }
+            };
+            req.query = {
+              from: '02/02/2017',
+              to: '03/02/2017',
+              user: 'mr_user'
+            };
+            const toAdjusted = '04/02/2017';
+            const matchFrom = sinon.match.object.and(momentMatcher(moment(req.query.from, 'DD/MM/YYYY')));
+            const matchTo = sinon.match.object.and(momentMatcher(moment(toAdjusted, 'DD/MM/YYYY')));
+            api.userActivityReport.withArgs('mrs-caseworker', matchFrom, matchTo, req.query.user)
+              .returns(Promise.resolve(records));
+
+            res.render = (view, data) => {
+              try {
+                view.should.equal('pages/user-activity');
+                data.should.have.property('user', req.query.user);
+                done();
+              } catch (err) {
+                done(err);
+              }
+            };
+
+            controller(req, res);
+          });
         });
       });
 

--- a/test/unit/lib/custom-validators.js
+++ b/test/unit/lib/custom-validators.js
@@ -26,8 +26,8 @@ describe('helper function', () => {
   describe('#addValidators', () => {
     it('should add the custom validators to an existing set of validators', () => {
       const v8s = {};
-      validators.addValidators(v8s).should.have.keys(['british-date', 'past', 'since']);
-      v8s.should.have.keys(['british-date', 'past', 'since']);
+      validators.addValidators(v8s).should.have.keys(['british-date', 'past', 'since', 'email-chars']);
+      v8s.should.have.keys(['british-date', 'past', 'since', 'email-chars']);
     });
   });
 
@@ -108,6 +108,30 @@ describe('custom validators', () => {
     it('should not accept dates before the specified date', () => {
       hof.validators.since(moment().add(-1, 'day').format('DD/MM/YYYY'), moment()).should.be.false;
       hof.validators.since(moment().add(-1, 'day').format('DDMMYYYY'), moment()).should.be.false;
+    });
+  });
+
+  describe('email-chars', () => {
+    it('should exist as a function', () => {
+      hof.validators.should.have.property('email-chars').that.is.a('function');
+    });
+
+    it('should accept an empty string', () => {
+      hof.validators['email-chars']('').should.be.true;
+    });
+
+    it('should accept all the standard email characters', () => {
+      hof.validators['email-chars']('my_E-mail+%20@here.com').should.be.true;
+    });
+
+    it('should accept parts of email addresses', () => {
+      hof.validators['email-chars']('@bingo.cz').should.be.true;
+    });
+
+    it('should not accept characters not suitable for email addresses', () => {
+      hof.validators['email-chars']('this won\'t work').should.be.false;
+      hof.validators['email-chars']('no*work').should.be.false;
+      hof.validators['email-chars']('also\tbad').should.be.false;
     });
   });
 });

--- a/views/pages/user-activity.html
+++ b/views/pages/user-activity.html
@@ -30,6 +30,7 @@ Audit information
 <div id="controls">
   {{#input-text}}from{{/input-text}}
   {{#input-text}}to{{/input-text}}
+  {{#input-text}}user{{/input-text}}
 </div>
 <div class="buttons">
   {{#input-submit}}search{{/input-submit}}
@@ -41,7 +42,7 @@ Audit information
 {{> partials-audit-report}}
 {{/audit}}
 {{#naudit}}
-<h2>No usage data found between {{from}} and {{to}}</h2>
+<h2>No usage data{{#user}} for '{{user}}'{{/user}} found between {{from}} and {{to}}</h2>
 {{/naudit}}
 
 {{/content}}

--- a/views/partials/audit-report.html
+++ b/views/partials/audit-report.html
@@ -1,4 +1,4 @@
-<h2>Showing audit data from {{from}}, to {{to}}</h2>
+<h2>Showing audit data{{#user}} for '{{user}}'{{/user}} from {{from}}, to {{to}}</h2>
 <label for="weekends">Show weekends?</label>
 <input id="weekends" name="weekends" type="checkbox" />
 <table class="audit">


### PR DESCRIPTION
Add a search filter to allow the User Activity report to be limited to a specific user (by entering an exact username) or group of users (by entering a common term to match usernames).