### PR TITLE
Switch based browser tests

### DIFF
--- a/Dockerfile-e2e
+++ b/Dockerfile-e2e
@@ -1,2 +1,2 @@
 FROM lev-web-testing
-ENTRYPOINT ["npm", "run", "chimp"]
+ENTRYPOINT ["npm", "run", "test:browser"]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chimp": "NODE_ENV=acceptance chimp --mocha --browser=phantomjs --path=./test/acceptance/spec/",
     "chimp:ff": "NODE_ENV=acceptance chimp --mocha --browser=firefox --path=./test/acceptance/spec/ --watch",
     "smoke": "chimp --mocha --browser=phantomjs --path=./test/smoke/",
+    "test:browser": "npm run $([ -n \"${SMOKE_TEST}\" ] && echo smoke || echo chimp)",
     "create:trigger": "touch ./.acceptance.trgr 2>/dev/null",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
The environment variable `SMOKE_TEST` can now be used to change the tests run by the `lev-web-e2e` image to choose between the E2E tests (default) and the smoke tests (example below).

```
docker run -e SMOKE_TEST=true lev-web-e2e
```