### PR TITLE
[LEVWEB-839] Env var to disable API verification

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,8 @@ const conf = {
   lev_tls: {
     key: process.env.LEV_TLS_KEY || null,
     cert: process.env.LEV_TLS_CERT || null,
-    ca: process.env.LEV_TLS_CA || null
+    ca: process.env.LEV_TLS_CA || null,
+    verify: String(process.env.LEV_TLS_VERIFY).match(/false/i) === null
   }
 };
 

--- a/lib/lev-request.js
+++ b/lib/lev-request.js
@@ -12,6 +12,10 @@ const addTlsConfig = (requestArgs) => {
     requestArgs.key = config.lev_tls.key ? fs.readFileSync(config.lev_tls.key) : undefined;
     requestArgs.cert = config.lev_tls.cert ? fs.readFileSync(config.lev_tls.cert) : undefined;
     requestArgs.ca = config.lev_tls.ca ? fs.readFileSync(config.lev_tls.ca) : undefined;
+
+    requestArgs.agentOptions = {
+      rejectUnauthorized: config.lev_tls.verify !== false
+    };
   }
 
   return requestArgs;

--- a/test/unit/lib/lev-request.js
+++ b/test/unit/lib/lev-request.js
@@ -42,7 +42,10 @@ describe('lib/lev-request', function() {
             url: 'http://testhost.com',
             key: 'TLS Key',
             cert: 'TLS Cert',
-            ca: 'TLS CA'
+            ca: 'TLS CA',
+            agentOptions: {
+              rejectUnauthorized: true
+            }
         });
     });
 


### PR DESCRIPTION
Adds an environment variable, LEV_TLS_VERIFY, that when set to 'false'
will disable verification of the API's server certificate.

Somewhat related to #293.