### PR TITLE
[LEVWEB-841] Pin webdriverio to v4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "rewire": "^2.5.2",
     "sass-lint": "^1.10.2",
     "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "webdriverio": "~4.8.0"
   },
   "snyk": true
 }


### PR DESCRIPTION
Pins the webdriverio module to v4.8 to workaround what appears to be a
bug in the most recent v4 in the `getText` method when used to get data
from tables.