### PR TITLE
[LEVWEB-585] Don't pin slack-plugin version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -159,7 +159,7 @@ pipeline:
       status: success
 
   notify_slack_failure:
-    image: plugins/slack:1.0
+    image: plugins/slack
     secrets:
       - SLACK_WEBHOOK
     channel: alerts


### PR DESCRIPTION
In the docs they no longer pin the version so we probably shouldn't
either.