### PR TITLE
[LEVWEB-871] Limit audit date range

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -85,6 +85,9 @@ const userActivityReport = (accessToken, from, to, userFilter) => {
   if (from.isAfter(to)) {
     throw new RangeError('"from" date must be before "to" date for the User Activity report');
   }
+  if (moment(from).add(config.MAX_AUDIT_RANGE, 'days').isBefore(to)) {
+    throw new RangeError(`maximum date range exceeded (should be less than ${config.MAX_AUDIT_RANGE} days)`);
+  }
 
   const data = {
     from: from,

--- a/api/index.js
+++ b/api/index.js
@@ -66,7 +66,7 @@ const findBirths = (searchFields, accessToken) => {
     : findByNameDOB(searchFields, accessToken);
 };
 
-const userActivityReport = (accessToken, from, to, userFilter) => {
+const userActivityReport = (accessToken, from, to, userFilter) => { // eslint-disable-line complexity
   if (!accessToken) {
     throw new ReferenceError('The "accessToken" parameter was not provided');
   }

--- a/config.js
+++ b/config.js
@@ -19,7 +19,8 @@ const conf = {
     cert: process.env.LEV_TLS_CERT || null,
     ca: process.env.LEV_TLS_CA || null,
     verify: String(process.env.LEV_TLS_VERIFY).match(/false/i) === null
-  }
+  },
+  MAX_AUDIT_RANGE: 92
 };
 
 module.exports = conf;

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "winston": "^1.0.1"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
+    "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chimp": "^0.42.0",
     "eslint": "^3.4.0",

--- a/test/acceptance/config.js
+++ b/test/acceptance/config.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const config = require('../../config');
+
 module.exports = {
   url: process.env.TEST_URL || 'http://localhost:8002',
   env: process.env.ENV || 'local',
   username: process.env.USERNAME,
-  password: process.env.PASSWORD
+  password: process.env.PASSWORD,
+  MAX_AUDIT_RANGE: config.MAX_AUDIT_RANGE
 };

--- a/test/acceptance/spec/23-user-activity.js
+++ b/test/acceptance/spec/23-user-activity.js
@@ -370,6 +370,24 @@ describe('User Activity', () => {
       });
     });
 
+    // placeholder test for making search date range limit check part of validation, instead of a 500 error
+    describe.skip(`with a date range greater than ${testConfig.MAX_AUDIT_RANGE} days`, () => {
+      before(() => {
+        browser.generateReport(
+          moment().subtract(testConfig.MAX_AUDIT_RANGE + 1, 'days').format('DD/MM/YYYY'),
+          moment().format('DD/MM/YYYY')
+        );
+      });
+
+      it('displays an error message', () => {
+        browser.getText('h2').should.contain('Fix the following error');
+      });
+
+      it('requests a reduced date range', () => {
+        browser.getText('a').should.contain(`Please enter a date range less than ${testConfig.MAX_AUDIT_RANGE} days`);
+      });
+    });
+
     describe('with invalid characters in the user search filter', () => {
       before(() => {
         browser.generateReport(

--- a/test/acceptance/spec/23-user-activity.js
+++ b/test/acceptance/spec/23-user-activity.js
@@ -18,7 +18,7 @@ describe('User Activity', () => {
   describe('submitting valid search dates', () => {
     describe('returning no audit data', () => {
       const from = '01/01/1800';
-      const to = '01/01/1900';
+      const to = '01/04/1800';
 
       before(() => {
         browser.generateReport(from, to);
@@ -192,7 +192,7 @@ describe('User Activity', () => {
   describe('adding a user filter', () => {
     describe('returning no audit data', () => {
       const from = '01/01/1800';
-      const to = '01/01/1900';
+      const to = '01/04/1800';
 
       before(() => {
         browser.generateReport(from, to, user);

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -587,6 +587,11 @@ describe('api/index.js', () => {
         expect(() => api.userActivityReport('user', moment().add(1, 'days'), moment())).to.throw(RangeError)
       );
 
+      it(`should throw a RangeError if the date range is greater than the ${config.MAX_AUDIT_RANGE} day limit`, () =>
+        expect(() => api.userActivityReport('user', moment().subtract(config.MAX_AUDIT_RANGE + 1, 'days'), moment()))
+          .to.throw(RangeError, `less than ${config.MAX_AUDIT_RANGE} days`)
+      );
+
       describe('as a proper range', () => {
         let result;
         const from = '2001-01-01';

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -572,13 +572,13 @@ describe('api/index.js', () => {
         expect(from => api.userActivityReport('user', from, moment())).to.throw(ReferenceError);
         expect(() => api.userActivityReport('user', moment())).to.throw(ReferenceError);
       });
-      it('should throw a ReferenceError if either parameter is not a `moment` date object', () => {
+      it('should throw a TypeError if either parameter is not a `moment` date object', () => {
         expect(() => api.userActivityReport('user', 'from', moment())).to.throw(TypeError);
         expect(() => api.userActivityReport('user', moment(), 'to')).to.throw(TypeError);
       });
-      it('should throw a ReferenceError if either parameter is not a valid date object', () => {
+      it('should throw a RangeError if either parameter is not a valid date object', () => {
         expect(() => api.userActivityReport('user', moment('from'), moment())).to.throw(RangeError);
-        expect(() => api.userActivityReport('user', moment(), moment('2017-02-29'))).to.throw(RangeError);
+        expect(() => api.userActivityReport('user', moment('2017-02-27'), moment('2017-02-29'))).to.throw(RangeError);
       });
     });
 


### PR DESCRIPTION
Constrain the maximum audit report date range for the table to `92 days` (roughly a Quarter).
This should stop the accidental crippling of LEV by requests for MASSIVE amounts of audit data!