### PR TITLE
[LEVWEB-475][LEVWEB-476] Harden headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,9 +22,6 @@ if (config.env !== 'acceptance') {
   app.use(churchill(logger));
 }
 
-// add health check endpoints
-app.use(require('./lib/health'));
-
 app.use('/public', express.static(path.resolve(__dirname, './public')));
 
 app.use(function setAssetPath(req, res, next) {
@@ -52,6 +49,9 @@ app.use((req, res, next) => {
   res.set('X-Frame-Options', 'DENY');
   next();
 });
+
+// add health check endpoints
+app.use(require('./lib/health'));
 
 require('./routes')(app);
 

--- a/app.js
+++ b/app.js
@@ -47,6 +47,12 @@ app.engine('html', require('hogan-express-strict'));
 app.use(i18n.middleware());
 app.use(mixins(fields));
 
+app.use((req, res, next) => {
+  res.set('Cache-Control', 'no-cache; no-store');
+  res.set('X-Frame-Options', 'DENY');
+  next();
+});
+
 require('./routes')(app);
 
 app.use(require('./middleware/not-found')());

--- a/test/acceptance/spec/06-headers.js
+++ b/test/acceptance/spec/06-headers.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const request = require('request');
+const url = require('../config').url;
+
+describe('Header check', () => {
+  let response;
+
+  const makeRequest = (path, done) => {
+    request.get(url + path, (err, res) => {
+      response = res;
+      done(err);
+    });
+  };
+
+  describe('the main search endpoint "/"', () => {
+    before(done => {
+      makeRequest('/', done);
+    });
+
+    it('should have the cache-control and x-frame-options headers', () =>
+      expect(response).to.include({ statusCode: 200 })
+        .and.have.property('headers').that.includes({
+        'cache-control': 'no-cache; no-store',
+        'x-frame-options': 'DENY'
+      }));
+  });
+
+  describe('the static resource endpoint for CSS styles "/public/css/app.css"', () => {
+    before(done => {
+      makeRequest('/public/css/app.css', done);
+    });
+
+    it('should not have the x-frame-options header, or have cache-control set to DENY', () => {
+      expect(response).to.include({ statusCode: 200 }).and.have.property('headers');
+      expect(response.headers).not.to.have.property('x-frame-options');
+      expect(response.headers).not.to.have.property('cache-control', 'no-cache; no-store');
+    });
+  });
+});


### PR DESCRIPTION
Adds some headers for security hardening. Should discourage caching and
the use of frames.

These headers are not applied to static assets.