### PR TITLE
Fix: Missing fields in deaths and marriages

### DIFF
--- a/api/helpers.js
+++ b/api/helpers.js
@@ -149,11 +149,13 @@ const processMarriageRecord = r => ({
   },
   bride: {
     forenames: r.bride.forenames,
-    surname: r.bride.surname
+    surname: r.bride.surname,
+    sex: r.bride.sex
   },
   groom: {
     forenames: r.groom.forenames,
-    surname: r.groom.surname
+    surname: r.groom.surname,
+    sex: r.groom.sex
   }
 });
 

--- a/views/pages/death-details.html
+++ b/views/pages/death-details.html
@@ -77,7 +77,7 @@
       </tr>
       <tr>
         <th><span class="visuallyhidden" aria-hidden="true">Registration </span>Administrative area</th>
-        <td>{{record.registrar.adminstrativeArea}}</td>
+        <td>{{record.registrar.administrativeArea}}</td>
       </tr>
       <tr>
         <th>Date of registration</th>

--- a/views/pages/marriage-details.html
+++ b/views/pages/marriage-details.html
@@ -68,7 +68,7 @@
       </tr>
       <tr>
         <th><span class="visuallyhidden" aria-hidden="true">Registration </span>Administrative area</th>
-        <td>{{record.registrar.adminstrativeArea}}</td>
+        <td>{{record.registrar.administrativeArea}}</td>
       </tr>
       <tr>
         <th>Date of registration</th>


### PR DESCRIPTION
Fixes some bugs in which the new deaths and marriages pages pages were
missing some fields.