### PR TITLE
[LEVWEB-921] Declare user by UID rather than name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN npm run postinstall && \
 ENTRYPOINT ["/app/entrypoint.sh"]
 EXPOSE 8001
 
-USER nodejs
+USER 998
 CMD [ "start" ]


### PR DESCRIPTION
This is to work around an issue in an upcoming version of Kubernetes.