### PR TITLE
[LEVWEB-954] Fix: Buttons in flags alignment

### DIFF
--- a/assets/scss/details.scss
+++ b/assets/scss/details.scss
@@ -13,6 +13,11 @@ $warn-border-colour: #CCAA00;
   border-left: em(10) solid $border-colour;
   padding: em(15);
   margin-bottom: em(20);
+
+  .button {
+    margin: 0;
+    display: inline;
+  }
 }
 
 .alert {


### PR DESCRIPTION
Currently buttons placed inside flags are out of alignment due to their
display mode of `inline-block` as well their margins.