### PR TITLE
[LEVWEB-1033] Update Sign-out link

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -79,7 +79,7 @@
             <div id="proposition-name"><a href="{{absBaseUrl}}">{{$journeyHeader}}{{/journeyHeader}}</a></div>
           </div>
           <ul id="nav">
-            <li><a id="sign-out" href="/oauth/logout?redirect=%2F">Sign out</a></li>
+            <li><a id="sign-out" href="/oauth/logout">Sign out</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Removed the explicit redirect on the 'Sign out' link to take advantage
of keycloak-proxy's default of providing the hostname through to
Keycloak.