### PR TITLE
Update death and marriage search fields

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://172.17.0.1:2375
       - DOCKER_IMAGE=lev-web
-      - MOCK_IMAGE=quay.io/ukhomeofficedigital/lev-api:0.0
+      - MOCK_IMAGE=quay.io/ukhomeofficedigital/lev-api:0.5
     commands:
       - DOCKER_NAME="$${DOCKER_IMAGE}-$${DRONE_BUILD_NUMBER}"
       - docker build -t "$${DOCKER_IMAGE}" .

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -25,7 +25,7 @@ const buildBirthParams = (attrs) => _.pickBy({
 const buildDeathParams = (attrs) => _.pickBy({
   surname: attrs.surname,
   forenames: attrs.forenames,
-  dateOfBirth: attrs.dob && toInternationalDateFormat(attrs.dob)
+  date: attrs.dobd && toInternationalDateFormat(attrs.dobd)
 }, _.identity);
 const buildMarriageParams = (attrs) => _.pickBy({
   surname: attrs.surname,

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -30,7 +30,7 @@ const buildDeathParams = (attrs) => _.pickBy({
 const buildMarriageParams = (attrs) => _.pickBy({
   surname: attrs.surname,
   forenames: attrs.forenames,
-  dateOfBirth: attrs.dob && toInternationalDateFormat(attrs.dob)
+  dateOfMarriage: attrs.dom && toInternationalDateFormat(attrs.dom)
 }, _.identity);
 const buildAuditParams = (attrs) => _.pickBy({
   from: toInternationalDateFormat(attrs.from),

--- a/api/index.js
+++ b/api/index.js
@@ -104,13 +104,13 @@ const findDeaths = (searchFields, accessToken) => {
     : findDeathsByNameDate(searchFields, accessToken);
 };
 
-const findMarriagesByNameDOB = (searchFields, accessToken) => {
+const findMarriagesByNameDOM = (searchFields, accessToken) => {
   if (searchFields === undefined) {
-    throw new ReferenceError('findMarriagesByNameDOB(): first argument, searchFields, was not defined');
+    throw new ReferenceError('findMarriagesByNameDOM(): first argument, searchFields, was not defined');
   } else if (!(searchFields instanceof Object)) {
-    throw new TypeError('findMarriagesByNameDOB(): first argument, searchFields, must be an object');
+    throw new TypeError('findMarriagesByNameDOM(): first argument, searchFields, must be an object');
   } else if (accessToken !== undefined && typeof accessToken !== 'string') {
-    throw new TypeError('findMarriagesByNameDOB(): second argument, accessToken, must be a string');
+    throw new TypeError('findMarriagesByNameDOM(): second argument, accessToken, must be a string');
   }
 
   return requestData(helpers.buildQueryUri(marriageSearch, searchFields), accessToken)
@@ -143,7 +143,7 @@ const findMarriages = (searchFields, accessToken) => {
 
   return systemNumber
     ? findMarriageBySystemNumber(systemNumber, accessToken).then((data) => [data])
-    : findMarriagesByNameDOB(searchFields, accessToken);
+    : findMarriagesByNameDOM(searchFields, accessToken);
 };
 
 const userActivityReport = (accessToken, from, to, userFilter) => { // eslint-disable-line complexity

--- a/api/index.js
+++ b/api/index.js
@@ -62,13 +62,13 @@ const findBirths = (searchFields, accessToken) => {
     : findByNameDOB(searchFields, accessToken);
 };
 
-const findDeathsByNameDOB = (searchFields, accessToken) => {
+const findDeathsByNameDate = (searchFields, accessToken) => {
   if (searchFields === undefined) {
-    throw new ReferenceError('findByNameDOB(): first argument, searchFields, was not defined');
+    throw new ReferenceError('findDeathsByNameDate(): first argument, searchFields, was not defined');
   } else if (!(searchFields instanceof Object)) {
-    throw new TypeError('findDeathsByNameDOB(): first argument, searchFields, must be an object');
+    throw new TypeError('findDeathsByNameDate(): first argument, searchFields, must be an object');
   } else if (accessToken !== undefined && typeof accessToken !== 'string') {
-    throw new TypeError('findDeathsByNameDOB(): second argument, accessToken, must be a string');
+    throw new TypeError('findDeathsByNameDate(): second argument, accessToken, must be a string');
   }
 
   return requestData(helpers.buildQueryUri(deathSearch, searchFields), accessToken)
@@ -101,7 +101,7 @@ const findDeaths = (searchFields, accessToken) => {
 
   return systemNumber
     ? findDeathBySystemNumber(systemNumber, accessToken).then((data) => [data])
-    : findDeathsByNameDOB(searchFields, accessToken);
+    : findDeathsByNameDate(searchFields, accessToken);
 };
 
 const findMarriagesByNameDOB = (searchFields, accessToken) => {

--- a/docker-compose-local-api.yml
+++ b/docker-compose-local-api.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   api:
-    image: quay.io/ukhomeofficedigital/lev-api:0.0
+    image: quay.io/ukhomeofficedigital/lev-api:0.5
     environment:
       - LISTEN_HOST=0.0.0.0
       - LISTEN_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       API_HOST: mock-api
       API_PORT: 8080
   mock-api:
-    image: quay.io/ukhomeofficedigital/lev-api:0.0
+    image: quay.io/ukhomeofficedigital/lev-api:0.5
     environment:
       MOCK: "true"
     ports:

--- a/fields/death.js
+++ b/fields/death.js
@@ -24,7 +24,7 @@ module.exports = {
       field: 'system-number'
     }
   },
-  'dob': {
+  'dobd': {
     validate: ['british-date', 'past', 'required'],
     dependent: {
       value: '',

--- a/fields/marriage.js
+++ b/fields/marriage.js
@@ -24,7 +24,7 @@ module.exports = {
       field: 'system-number'
     }
   },
-  'dob': {
+  'dom': {
     validate: ['british-date', 'past', 'required'],
     dependent: {
       value: '',

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -22,6 +22,10 @@
       "label": "Date of birth",
       "hint": "For example, 18/11/2009"
     },
+    "dobd": {
+      "label": "Date of birth or death",
+      "hint": "For example, 08/05/1945"
+    },
     "from": {
       "label": "Search from",
       "hint": "For example 15/1/2017"
@@ -52,6 +56,11 @@
       "british-date": "Please enter a date of birth in the correct format",
       "past": "Please enter a date of birth in the past",
       "since": "Please enter a date after our records began (1 July 2009)"
+    },
+    "dobd": {
+      "required": "Please enter a date",
+      "british-date": "Please enter a date in the correct format",
+      "past": "Please enter a date in the past"
     },
     "from": {
       "required": "Please enter a date to search from",

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -26,6 +26,10 @@
       "label": "Date of birth or death",
       "hint": "For example, 08/05/1945"
     },
+    "dom": {
+      "label": "Date of marriage",
+      "hint": "For example, 18/11/2009"
+    },
     "from": {
       "label": "Search from",
       "hint": "For example 15/1/2017"
@@ -61,6 +65,12 @@
       "required": "Please enter a date",
       "british-date": "Please enter a date in the correct format",
       "past": "Please enter a date in the past"
+    },
+    "dom": {
+      "required": "Please enter a date of marriage",
+      "british-date": "Please enter a date of marriage in the correct format",
+      "past": "Please enter a date of marriage in the past",
+      "since": "Please enter a date after our records began (1 July 2009)"
     },
     "from": {
       "required": "Please enter a date to search from",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:acceptance:sub": "npm-run-all -pr start:acceptance chimp",
     "test:ci": "npm-run-all -s lint lint:sass cover check-coverage chimp",
     "start:acceptance": "NODE_ENV=acceptance npm start",
-    "start:mockapi": "docker run -d -p 8080:8080 --name lev-api-mock --env 'MOCK=true' docker.digital.homeoffice.gov.uk/lev-api:0.0",
+    "start:mockapi": "docker run -d -p 8080:8080 --name lev-api-mock --env 'MOCK=true' docker.digital.homeoffice.gov.uk/lev-api:0.5",
     "stop:mockapi": "npm-run-all -s -c --silent stop:mockapi:kill stop:mockapi:rm",
     "stop:mockapi:kill": "docker kill lev-api-mock || true",
     "stop:mockapi:rm": "docker rm lev-api-mock || true",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lev-web",
   "description": "Life Event Verification Web Interface",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "app.js",
   "scripts": {
     "start": "node .",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "moment-round": "^1.0.1",
-    "node-sass": "^3.7.0",
+    "node-sass": "^4.9.3",
     "npm-run-all": "^3.1.2",
     "request": "^2.85.0",
     "snyk": "^1.83.0",

--- a/views/pages/death-results.html
+++ b/views/pages/death-results.html
@@ -16,7 +16,7 @@
           {{system-number}}
           {{forenames}}
           {{surname}}
-          {{dob}}
+          {{dobd}}
         {{/query}}
       </span>
     {{/page-header}}

--- a/views/pages/death-search.html
+++ b/views/pages/death-search.html
@@ -41,7 +41,7 @@
       </details>
       {{#input-text}}surname{{/input-text}}
       {{#input-text}}forenames{{/input-text}}
-      {{#input-text}}dob{{/input-text}}
+      {{#input-text}}dobd{{/input-text}}
       <div class="buttons">
         {{#input-submit}}search{{/input-submit}}
       </div>

--- a/views/pages/marriage-results.html
+++ b/views/pages/marriage-results.html
@@ -16,7 +16,7 @@
           {{system-number}}
           {{forenames}}
           {{surname}}
-          {{dob}}
+          {{dom}}
         {{/query}}
       </span>
     {{/page-header}}

--- a/views/pages/marriage-search.html
+++ b/views/pages/marriage-search.html
@@ -41,7 +41,7 @@
       </details>
       {{#input-text}}surname{{/input-text}}
       {{#input-text}}forenames{{/input-text}}
-      {{#input-text}}dob{{/input-text}}
+      {{#input-text}}dom{{/input-text}}
       <div class="buttons">
         {{#input-submit}}search{{/input-submit}}
       </div>


### PR DESCRIPTION
Updates the search fields for the death and marriage prototypes according to the user needs. Specifically marriage searches are now done using the date of marriage and death searches can provide the date of death instead of the date of birth.

Also:
- node-sass is upgraded to aid development on Node.js v8
- The version is bumped to reflect the interface change and the new API version required