### PR TITLE
[LEVWEB-1078] Fix brittle acceptance test

### DIFF
--- a/test/acceptance/spec/23-user-activity.js
+++ b/test/acceptance/spec/23-user-activity.js
@@ -114,7 +114,7 @@ describe('User Activity', () => {
         });
 
         it('each row should display the username', () => {
-          columns[0].should.equal(user);
+          columns.should.contain(user);
         });
 
         it('each row should have a column for each day with the search count', () => {


### PR DESCRIPTION
It isn't safe to assume that the test user will always appear in the
first of the audit data.