### PR TITLE
[LEVWEB-1162] Remove limit from audit form

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -162,9 +162,6 @@ const userActivityReport = (accessToken, from, to, userFilter) => {
   if (from.isAfter(to)) {
     throw new RangeError('"from" date must be before "to" date for the User Activity report');
   }
-  if (moment(from).add(config.MAX_AUDIT_RANGE, 'days').isBefore(to)) {
-    throw new RangeError(`maximum date range exceeded (should be less than ${config.MAX_AUDIT_RANGE} days)`);
-  }
   if (userFilter !== undefined && typeof userFilter !== 'string') {
     throw new TypeError('The "userFilter" parameter must be a string');
   }

--- a/api/index.js
+++ b/api/index.js
@@ -146,7 +146,7 @@ const findMarriages = (searchFields, accessToken) => {
     : findMarriagesByNameDOM(searchFields, accessToken);
 };
 
-const userActivityReport = (accessToken, from, to, userFilter) => { // eslint-disable-line complexity
+const userActivityReport = (accessToken, from, to, userFilter) => {
   if (accessToken !== undefined && typeof accessToken !== 'string') {
     throw new TypeError('The "accessToken" parameter must be a string');
   }

--- a/config.js
+++ b/config.js
@@ -23,8 +23,7 @@ const conf = {
     cert: process.env.LEV_TLS_CERT || null,
     ca: process.env.LEV_TLS_CA || null,
     verify: String(process.env.LEV_TLS_VERIFY).match(/false/i) === null
-  },
-  MAX_AUDIT_RANGE: 92
+  }
 };
 
 module.exports = conf;

--- a/test/acceptance/config.js
+++ b/test/acceptance/config.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const config = require('../../config');
-
 module.exports = {
   url: process.env.TEST_URL || 'http://localhost:8001',
   env: process.env.ENV || 'local',
   username: process.env.USERNAME,
-  password: process.env.PASSWORD,
-  MAX_AUDIT_RANGE: config.MAX_AUDIT_RANGE
+  password: process.env.PASSWORD
 };

--- a/test/acceptance/spec/23-user-activity.js
+++ b/test/acceptance/spec/23-user-activity.js
@@ -378,20 +378,6 @@ describe('User Activity', () => {
       it('requests a past date', () => browser.getText('a').should.contain('Please enter a proper date range'));
     });
 
-    // temporary test checks error page works as expected, should eventually be replaced by the next (skipped) test
-    describe(`with a date range greater than ${testConfig.MAX_AUDIT_RANGE} days`, () => {
-      before(() => {
-        browser.generateReport(
-          moment().subtract(testConfig.MAX_AUDIT_RANGE + 1, 'days').format('DD/MM/YYYY'),
-          moment().format('DD/MM/YYYY')
-        );
-      });
-
-      it('displays an error message', () => browser.getText('h1').should.equal('Error'));
-      it('requests a reduced date range', () => browser.getText('p').should.equal(
-        `maximum date range exceeded (should be less than ${testConfig.MAX_AUDIT_RANGE} days)`));
-    });
-
     describe('with invalid characters in the user search filter', () => {
       before(() => {
         browser.generateReport(

--- a/test/acceptance/spec/23-user-activity.js
+++ b/test/acceptance/spec/23-user-activity.js
@@ -392,20 +392,6 @@ describe('User Activity', () => {
         `maximum date range exceeded (should be less than ${testConfig.MAX_AUDIT_RANGE} days)`));
     });
 
-    // placeholder test for making search date range limit check part of validation, instead of a 500 error
-    describe.skip(`with a date range greater than ${testConfig.MAX_AUDIT_RANGE} days`, () => {
-      before(() => {
-        browser.generateReport(
-          moment().subtract(testConfig.MAX_AUDIT_RANGE + 1, 'days').format('DD/MM/YYYY'),
-          moment().format('DD/MM/YYYY')
-        );
-      });
-
-      it('displays an error message', () => browser.getText('h2').should.contain('Fix the following error'));
-      it('requests a reduced date range', () =>
-        browser.getText('a').should.contain(`Please enter a date range less than ${testConfig.MAX_AUDIT_RANGE} days`));
-    });
-
     describe('with invalid characters in the user search filter', () => {
       before(() => {
         browser.generateReport(

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -578,12 +578,6 @@ describe('api/index.js', () => {
         expect(() => api.userActivityReport(accessToken, moment().add(1, 'days'), moment())).to.throw(RangeError)
       );
 
-      const days = config.MAX_AUDIT_RANGE + 1;
-      it(`should throw a RangeError if the date range is greater than the ${config.MAX_AUDIT_RANGE} day limit`, () =>
-        expect(() => api.userActivityReport(accessToken, moment().subtract(days, 'days'), moment()))
-          .to.throw(RangeError, `less than ${config.MAX_AUDIT_RANGE} days`)
-      );
-
       describe('as a proper range', () => {
         let result;
         const from = '2001-01-01';


### PR DESCRIPTION
We limited the data that could be pulled from the audit page to work around a performance issue in the Scala API. As this is no longer in place we can remove it.