### PR TITLE
[LEVWEB-1167] Gender neutral terms on marriages

### DIFF
--- a/views/pages/marriage-details.html
+++ b/views/pages/marriage-details.html
@@ -48,102 +48,102 @@
         <td>{{record.placeOfMarriage}}</td>
       </tr>
       <tr class="section-head">
-        <th colspan="2">Groom</th>
+        <th colspan="2">Partner 1</th>
       </tr>
       <tr>
-        <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Surname</th>
+        <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Surname</th>
         <td>{{record.groom.surname}}</td>
       </tr>
       <tr>
-        <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Forename(s)</th>
+        <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Forename(s)</th>
         <td>{{record.groom.forenames}}</td>
       </tr>
       {{#showAll}}
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Age</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Age</th>
             <td>{{record.groom.age}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Occupation</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Occupation</th>
             <td>{{record.groom.occupation}}</td>
         </tr>
       {{/showAll}}
       <tr>
-        <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Address</th>
+        <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Address</th>
         <td>{{record.groom.address}}</td>
       </tr>
       {{#showAll}}
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Condition</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Condition</th>
             <td>{{record.groom.condition}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Groom's </span>Signature</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 1's </span>Signature</th>
             <td>{{record.groom.signature}}</td>
         </tr>
       {{/showAll}}
       <tr class="section-head">
-        <th colspan="2">Bride</th>
+        <th colspan="2">Partner 2</th>
       </tr>
       <tr>
-        <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Surname</th>
+        <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Surname</th>
         <td>{{record.bride.surname}}</td>
       </tr>
       <tr>
-        <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Forename(s)</th>
+        <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Forename(s)</th>
         <td>{{record.bride.forenames}}</td>
       </tr>
       {{#showAll}}
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Age</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Age</th>
             <td>{{record.bride.age}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Occupation</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Occupation</th>
             <td>{{record.bride.occupation}}</td>
         </tr>
       {{/showAll}}
       <tr>
-        <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Address</th>
+        <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Address</th>
         <td>{{record.bride.address}}</td>
       </tr>
       {{#showAll}}
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Condition</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Condition</th>
             <td>{{record.bride.condition}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Bride's </span>Signature</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Partner 2's </span>Signature</th>
             <td>{{record.bride.signature}}</td>
         </tr>
         <tr class="section-head">
-            <th colspan="2">Father of the groom</th>
+            <th colspan="2">Father of partner 1</th>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Father of the groom's </span>Surname</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Father of partner 1's </span>Surname</th>
             <td>{{record.fatherOfGroom.surname}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Father of the groom's </span>Forename(s)</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Father of partner 1's </span>Forename(s)</th>
             <td>{{record.fatherOfGroom.forenames}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Father of the groom's </span>Occupation</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Father of partner 1's </span>Occupation</th>
             <td>{{record.fatherOfGroom.occupation}}</td>
         </tr>
         <tr class="section-head">
-            <th colspan="2">Father of the bride</th>
+            <th colspan="2">Father of partner 2</th>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Father of the bride's </span>Surname</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Father of partner 2's </span>Surname</th>
             <td>{{record.fatherOfBride.surname}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Father of the bride's </span>Forename(s)</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Father of partner 2's </span>Forename(s)</th>
             <td>{{record.fatherOfBride.forenames}}</td>
         </tr>
         <tr>
-            <th><span class="visuallyhidden" aria-hidden="true">Father of the bride's </span>Occupation</th>
+            <th><span class="visuallyhidden" aria-hidden="true">Father of partner 2's </span>Occupation</th>
             <td>{{record.fatherOfBride.occupation}}</td>
         </tr>
         <tr class="section-head">


### PR DESCRIPTION
Switches to using gender neutral terms on the marriage details page.

In the future we could look at changing the terms we use depending on
whether it is a gay marriage or not.