### PR TITLE
Make CI more reliable

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ pipeline:
       - DOCKER_REPO_MOCK=docker.digital.homeoffice.gov.uk
       - DOCKER_USERNAME_MOCK=lev-kube
     commands:
-      - make test
+      - make 'compose_project_name=lev-web-${DRONE_BUILD_NUMBER}' test
     when:
       event: pull_request
 

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ docker-test-deps: docker-compose-deps
 docker:
 	docker build -t '$(DOCKER_IMAGE)' .
 
-docker-compose: docker-compose-deps docker
+docker-compose: docker-compose-deps
 	docker-compose build
 
-docker-test: docker-test-deps docker
+docker-test: docker-test-deps
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' stop
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' rm -vfs
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 DOCKER_IMAGE ?= lev-web
 
 perf_test_image = quay.io/ukhomeofficedigital/artillery-ci:0.3.2
-compose_network = levweb_default
 
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
+
+compose_project_name = $(current_dir)
+compose_network != echo "$$(echo '$(compose_project_name)' | tr -d '[\-_]')_default"
 probe_network = docker network ls | grep -q '$(compose_network)'
 
 docker-compose-deps:
@@ -17,8 +21,13 @@ docker:
 docker-compose: docker-compose-deps docker
 	docker-compose build
 
-docker-test: docker-test-deps docker-compose-clean docker-compose
-	docker-compose up &> /dev/null &
+docker-test: docker-test-deps docker
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' stop
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' rm -vfs
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' pull
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' build
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' up &> /dev/null &
 	eval $(probe_network); \
 	while [ $$? -ne 0 ]; do \
 		echo ...; \
@@ -26,7 +35,7 @@ docker-test: docker-test-deps docker-compose-clean docker-compose
 		eval $(probe_network); \
 	done; true
 	docker run --net '$(compose_network)' --env "TEST_CONFIG=$$(cat ./test/perf/artillery.config.yml)" --env "MEDIAN_LATENCY=500" --env "WAIT_URL=lev-web:8001/readiness" --env "TEST_URL=lev-web:8001" '$(perf_test_image)'
-	docker-compose stop
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
 
 docker-compose-clean:
 	docker-compose stop

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  lev-web:
+    build: .
+    environment:
+      NODE_ENV: test
+      API_HOST: mock-api
+      API_PORT: 8080
+  mock-api:
+    image: quay.io/ukhomeofficedigital/lev-api:0.7
+    environment:
+      MOCK: "true"


### PR DESCRIPTION
No longer tries to take ports on the host when testing in Docker and
also attempts to tear down any previous builds before testing.