### PR TITLE
Fix failing performance tests in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 #ide specific
 .idea/
 
-node_modules
+node_modules/
+.git/
 coverage
 public
 *.log
@@ -12,3 +13,5 @@ api/mock/lev-api-docs
 artefacts
 Dockerfile
 E2E_test_Dockerfile
+
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ USER root
 RUN apk del --no-cache \
       g++ \
       make \
-      python \
- && chown -R app:app .
+      python
 
 USER 31337
 ENV LISTEN_HOST="0.0.0.0" \

--- a/Dockerfile-testing
+++ b/Dockerfile-testing
@@ -17,9 +17,6 @@ COPY . /app
 
 RUN npm run postinstall
 
-USER root
-RUN chown -R app:app .
-
 USER 31337
 ENTRYPOINT [ "npm", "run" ]
 CMD [ "test:ci" ]

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 
 compose_project_name = $(current_dir)
-compose_network != echo "$$(echo '$(compose_project_name)' | tr -d '[\-_]')_default"
-probe_network = docker network ls | grep -q '$(compose_network)'
+compose_network_regexp != echo "$$(echo '$(compose_project_name)' | sed -E 's/([-_])+/[-_]*/g')_default"
+probe_network = docker network ls | grep -o '$(compose_network_regexp)'
 
 docker-compose-deps:
 	docker-compose pull
@@ -25,16 +25,15 @@ docker-test: docker-test-deps
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' stop
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' rm -vfs
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
-	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' pull
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' build
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' up &> /dev/null &
-	eval $(probe_network); \
+	compose_network=`$(probe_network)`; \
 	while [ $$? -ne 0 ]; do \
 		echo ...; \
 		sleep 5; \
-		eval $(probe_network); \
-	done; true
-	docker run --net '$(compose_network)' --env "TEST_CONFIG=$$(cat ./test/perf/artillery.config.yml)" --env "MEDIAN_LATENCY=500" --env "WAIT_URL=lev-web:8001/readiness" --env "TEST_URL=lev-web:8001" '$(perf_test_image)'
+		compose_network=`$(probe_network)`; \
+	done; \
+	docker run --net "$${compose_network}" --env "TEST_CONFIG=$$(cat ./test/perf/artillery.config.yml)" --env "MEDIAN_LATENCY=500" --env "WAIT_URL=lev-web:8001/readiness" --env "TEST_URL=lev-web:8001" '$(perf_test_image)'
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
 
 docker-compose-clean:

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ probe_network = docker network ls | grep -o '$(compose_network_regexp)'
 docker-compose-deps:
 	docker-compose pull
 
-docker-test-deps: docker-compose-deps
+docker-test-deps:
 	docker pull '$(perf_test_image)'
+	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' pull
 
 docker:
 	docker build -t '$(DOCKER_IMAGE)' .
@@ -21,9 +22,7 @@ docker:
 docker-compose: docker-compose-deps
 	docker-compose build
 
-docker-test: docker-test-deps
-	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' stop
-	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' rm -vfs
+docker-test:
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' down -v
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' build
 	docker-compose -f docker-compose-test.yml -p '$(compose_project_name)' up &> /dev/null &


### PR DESCRIPTION
The performance tests currently fail in CI due to the docker-compose networks following a new format.

This PR also includes some attempts to speed up builds.