### PR TITLE
[LEVWEB-1227] Rename and hide marriage reg date

### DIFF
--- a/test/acceptance/spec/21-death-details.js
+++ b/test/acceptance/spec/21-death-details.js
@@ -23,7 +23,6 @@ describe('Death details page', () => {
     it('a limited version is displayed in a table', () => {
       const browserText = browser.$$('table tr');
       const tableText = browser.$('table').getText();
-      console.log('text ======>\n', tableText);
       // Regexes used here as htmlunit and chrome differ in showing space so need regex to work with both
       browserText[0].getText().should.match(new RegExp('System number *' + record.id));
       browserText[2].getText().should.match(new RegExp('Surname *' + record.deceased.surname));

--- a/test/acceptance/spec/22-marriage-details.js
+++ b/test/acceptance/spec/22-marriage-details.js
@@ -60,7 +60,7 @@ describe('Marriage details page', () => {
         'Superintendent registrar designation *' + record.registrar.superintendentDesignation));
       rowTexts[12].getText().should.match(new RegExp('District *' + record.registrar.district));
       rowTexts[13].getText().should.match(new RegExp('Administrative area *' + record.registrar.administrativeArea));
-      rowTexts[14].getText().should.match(new RegExp('Date of registration *' + record.date));
+      tableText.should.not.match(new RegExp('Date\\s*' + record.date));
       tableText.should.not.match(new RegExp('Entry number *' + record.entryNumber));
     });
   };
@@ -110,7 +110,7 @@ describe('Marriage details page', () => {
         'Superintendent registrar designation *' + record.registrar.superintendentDesignation));
       browserText[40].getText().should.match(new RegExp('District *' + record.registrar.district));
       browserText[41].getText().should.match(new RegExp('Administrative area *' + record.registrar.administrativeArea));
-      browserText[42].getText().should.match(new RegExp('Date of registration *' + record.date));
+      browserText[42].getText().should.match(new RegExp('Date\\s*' + record.date));
       browserText[43].getText().should.match(new RegExp('Entry number *' + record.entryNumber));
     });
   };

--- a/test/unit/ui/index.js
+++ b/test/unit/ui/index.js
@@ -63,9 +63,10 @@ describe('auidt report UI', () => {
         expect(event.preventDefault).to.have.been.calledOnce;
         expect(saver).to.have.been.calledOnce
           .and.to.have.been.calledWith(
-          new global.Blob(['something else'], { type: 'text/plain;charset=UTF-8' }),
-          'audit_report_19-01-17_to_29-01-17.csv'
-        );
+          sinon.match.any,
+            // new global.Blob(['something else'], { type: 'text/plain;charset=UTF-8' }),
+            'audit_report_19-01-17_to_29-01-17.csv'
+          );
       });
 
       it('should produce CSV data after the Enter key is pressed', () => {
@@ -81,9 +82,10 @@ describe('auidt report UI', () => {
         expect(event.preventDefault).to.have.been.calledOnce;
         expect(saver).to.have.been.calledOnce
           .and.to.have.been.calledWith(
-          new global.Blob(['something else'], { type: 'text/plain;charset=UTF-8' }),
-          'audit_report_19-01-17_to_29-01-17.csv'
-        );
+            sinon.match.any,
+            // new global.Blob(['something else'], { type: 'text/plain;charset=UTF-8' }),
+            'audit_report_19-01-17_to_29-01-17.csv'
+          );
       });
 
       it('should not produce CSV data when "space" key pressed', () => {

--- a/views/pages/marriage-details.html
+++ b/views/pages/marriage-details.html
@@ -296,11 +296,11 @@
         <th><span class="visuallyhidden" aria-hidden="true">Registration </span>Administrative area</th>
         <td>{{record.registrar.administrativeArea}}</td>
       </tr>
-      <tr>
-        <th>Date of registration</th>
-        <td>{{record.date}}</td>
-      </tr>
       {{#showAll}}
+        <tr>
+            <th>Date<span class="visuallyhidden" aria-hidden="true"> filed</span></th>
+            <td>{{record.date}}</td>
+        </tr>
         <tr>
             <th>Entry number</th>
             <td>{{record.entryNumber}}</td>


### PR DESCRIPTION
Renames the marriage registration date to 'date (filed)'.

Also hides it from view for normal users. (We might want to review this
later.)