### PR TITLE
[LEVWEB-1272] Display red flag for marginal notes

### DIFF
--- a/api/helpers.js
+++ b/api/helpers.js
@@ -391,8 +391,7 @@ const processPartnershipRecord = r => {
       surname: block(r.witness2.surname)
     },
     status: {
-      refer: blocked,
-      marginalNotes: r.status.marginalNotes
+      refer: blocked || r.status.marginalNote !== 'None'
     },
     previousRegistration: blocked ? {
       systemNumber: null

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -269,7 +269,7 @@ const processMarriageRecord = r => {
       signature: block(r.witness10.signature)
     },
     status: {
-      refer: blocked
+      refer: blocked || r.status.marginalNote !== 'None'
     },
     previousRegistration: blocked ? {
       systemNumber: null

--- a/test/unit/api/index.js
+++ b/test/unit/api/index.js
@@ -231,7 +231,7 @@ const partnershipResponse = {
   },
   'status': {
     'blocked': false,
-    'marginalNotes': null
+    'marginalNote': 'None'
   },
   'nextRegistration': null,
   'previousRegistration': null
@@ -339,8 +339,7 @@ const parsedPartnershipResponse = {
     surname: 'Other'
   },
   status: {
-    refer: false,
-    marginalNotes: null
+    refer: false
   },
   nextRegistration: {
     systemNumber: null,


### PR DESCRIPTION
Displays the red, "Refer to GRO" flag when a marginal note exists on a
marriage record.